### PR TITLE
Add gradient overlay to hero image

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,15 @@ body, html {
   overflow: hidden;
 }
 
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0));
+  pointer-events: none;
+  z-index: 1;
+}
+
 .hero .background {
   width: 100%;
   height: 100%;
@@ -32,6 +41,7 @@ body, html {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  z-index: 2;
 }
 
 .logo-container img {


### PR DESCRIPTION
## Summary
- add a pseudo-element overlay on the hero section to create a black gradient from bottom to top
- ensure the centered logo renders above the new overlay

## Testing
- no automated tests were run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dfdd7c76108327a47e93b3736ee970