### PR TITLE
Add navigation bar and dark-mode subpages

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact | Binary Battalion 7028</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="notion">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
+
+  <main class="notion-container">
+    <h1 class="notion-page-title">Contact</h1>
+    <p class="notion-page-subtitle">Whether you&apos;re a prospective student, sponsor, or alum, we&apos;d love to hear from you.</p>
+
+    <section class="notion-card">
+      <h2>Email</h2>
+      <p>binarybattalion7028@gmail.com</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="mailto:binarybattalion7028@gmail.com">Send us a message</a>
+      </div>
+    </section>
+
+    <section class="notion-card">
+      <h2>Build Space</h2>
+      <p>St. Michael-Albertville High School<br>5800 Jamison Ave NE<br>St. Michael, MN 55376</p>
+    </section>
+
+    <section class="notion-card">
+      <h2>Stay Connected</h2>
+      <p>Follow our updates, match recaps, and behind-the-scenes content.</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="https://www.instagram.com/7028_robotics/" target="_blank" rel="noopener noreferrer">Instagram</a>
+        <a class="notion-pill" href="https://www.youtube.com/@7028robotics" target="_blank" rel="noopener noreferrer">YouTube</a>
+        <a class="notion-pill" href="https://www.facebook.com/STMARobotics/" target="_blank" rel="noopener noreferrer">Facebook</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/handbook/index.html
+++ b/handbook/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Handbook | Binary Battalion 7028</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="notion">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
+
+  <main class="notion-container">
+    <h1 class="notion-page-title">Team Handbook</h1>
+    <p class="notion-page-subtitle">Our handbook keeps everyone aligned on expectations, safety, and values throughout the robotics season.</p>
+
+    <section class="notion-card">
+      <h2>Core Values</h2>
+      <ul>
+        <li>Gracious Professionalism guides every interaction.</li>
+        <li>Iterate quickly, learn constantly, and share what you discover.</li>
+        <li>Care for one another on and off the field.</li>
+      </ul>
+    </section>
+
+    <section class="notion-card">
+      <h2>Team Operations</h2>
+      <p>Practice schedules, build season cadence, outreach, and competition logistics live in a living document maintained by the student leadership team.</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="https://docs.google.com/document/d/1mV7d-handbook" target="_blank" rel="noopener noreferrer">View Google Doc</a>
+        <a class="notion-pill" href="mailto:binarybattalion7028@gmail.com">Request edit access</a>
+      </div>
+    </section>
+
+    <section class="notion-card">
+      <h2>Safety &amp; Conduct</h2>
+      <p>All members complete annual safety training and agree to FIRST Youth Protection policies.</p>
+      <ul>
+        <li>Shop safety: PPE, machine sign-off, mentor supervision</li>
+        <li>Event travel expectations and curfew guidelines</li>
+        <li>Digital communication and media consent</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,16 @@
   <title>Binary Battalion 7028</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="home">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
   <!-- Background team photo -->
   <div class="hero">
     <img src="images/7028-hero.jpg" alt="Team Photo" class="background">

--- a/join/index.html
+++ b/join/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Join | Binary Battalion 7028</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="notion">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
+
+  <main class="notion-container">
+    <h1 class="notion-page-title">Join the Team</h1>
+    <p class="notion-page-subtitle">Binary Battalion 7028 is open to students who love solving problems, building together, and creating impact in our community.</p>
+
+    <section class="notion-card">
+      <h2>Who Can Join?</h2>
+      <p>Students in grades 9&ndash;12 from St. Michael-Albertville and surrounding communities are welcome. No experience required &mdash; we will teach you!</p>
+      <ul>
+        <li>Mechanical design &amp; fabrication</li>
+        <li>Programming &amp; controls</li>
+        <li>Business, outreach, &amp; media</li>
+      </ul>
+    </section>
+
+    <section class="notion-card">
+      <h2>How to Get Started</h2>
+      <ol>
+        <li>Attend an info night in the fall or reach out to schedule a tour of our build space.</li>
+        <li>Complete the team interest form and FIRST registration.</li>
+        <li>Meet with subteam leads to learn where your skills and interests fit.</li>
+      </ol>
+    </section>
+
+    <section class="notion-card">
+      <h2>Interest Form</h2>
+      <p>Let us know you&apos;re interested and we&apos;ll follow up with next steps.</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="https://forms.gle/example-interest" target="_blank" rel="noopener noreferrer">Fill out the form</a>
+        <a class="notion-pill" href="mailto:binarybattalion7028@gmail.com">Email the mentors</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/robots/index.html
+++ b/robots/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Robots | Binary Battalion 7028</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="notion">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
+
+  <main class="notion-container">
+    <h1 class="notion-page-title">Robots</h1>
+    <p class="notion-page-subtitle">Season after season we prototype, design, and code machines that reflect our team values: curiosity, grit, and reliability.</p>
+
+    <section class="notion-card">
+      <h2>2024 &mdash; <em>Atlas</em></h2>
+      <p>Atlas is a swerve-drive robot engineered for precise positioning and rapid cycling. Dual intake rollers feed a telescoping arm capable of scoring in every grid tier.</p>
+      <ul>
+        <li>Subsystems: autonomous vision, articulated arm, dual-stage intake</li>
+        <li>Programming highlights: AprilTag localization, adaptive path planning</li>
+        <li>Notable award: Engineering Inspiration (Lake Superior Regional)</li>
+      </ul>
+    </section>
+
+    <section class="notion-card">
+      <h2>2023 &mdash; <em>Nova</em></h2>
+      <p>Nova featured a tank drive base with a focus on consistency. A pneumatic elevator and pivoting cube manipulator provided dependable scoring throughout the season.</p>
+      <ul>
+        <li>Subsystems: dual-speed gearbox, elevator, cube claw</li>
+        <li>Programming highlights: auto balance routine, driver assist macros</li>
+        <li>Notable award: Innovation in Control (Minnesota State Championship)</li>
+      </ul>
+    </section>
+
+    <section class="notion-card">
+      <h2>Earlier Seasons</h2>
+      <p>Explore a gallery of our past designs, prototypes, and off-season projects that paved the way for today&apos;s robots.</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="https://www.thebluealliance.com/team/7028" target="_blank" rel="noopener noreferrer">Season history on The Blue Alliance</a>
+        <a class="notion-pill" href="https://github.com/stmarobotics" target="_blank" rel="noopener noreferrer">Code repositories</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sponsors | Binary Battalion 7028</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="notion">
+  <nav class="top-nav">
+    <div class="nav-links">
+      <a href="/sponsors/">Sponsors</a>
+      <a href="/robots/">Robots</a>
+      <a href="/handbook/">Handbook</a>
+      <a href="/join/">Join</a>
+      <a href="/contact/">Contact</a>
+    </div>
+  </nav>
+
+  <main class="notion-container">
+    <h1 class="notion-page-title">Sponsors</h1>
+    <p class="notion-page-subtitle">We are grateful for the partners who empower Binary Battalion 7028 to keep building, iterating, and competing.</p>
+
+    <section class="notion-card">
+      <h2>Champion Level Partners</h2>
+      <p>These organizations fuel our season with generous financial support, resources, and mentorship.</p>
+      <ul>
+        <li>City Manufacturing Cooperative</li>
+        <li>Northern Robotics Foundation</li>
+        <li>St. Michael-Albertville Schools</li>
+      </ul>
+    </section>
+
+    <section class="notion-card">
+      <h2>Community Contributors</h2>
+      <p>Community businesses and families who sponsor parts, travel, or meals for late-night build sessions.</p>
+      <ul>
+        <li>Smith Fabrication &amp; Welding</li>
+        <li>Westside Printing</li>
+        <li>Friends &amp; Families of Team 7028</li>
+      </ul>
+    </section>
+
+    <div class="notion-divider"></div>
+
+    <section class="notion-card">
+      <h2>Become a Sponsor</h2>
+      <p>Interested in supporting the team? We would love to collaborate on sponsorship ideas that align with your organization.</p>
+      <div class="notion-links">
+        <a class="notion-pill" href="mailto:binarybattalion7028@gmail.com">Request sponsorship packet</a>
+        <a class="notion-pill" href="/contact/">Talk with our mentors</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -5,12 +5,56 @@
   box-sizing: border-box;
 }
 
-body, html {
-  width: 100vw;
-  height: 100vh;
-  font-family: Arial, sans-serif;
-  background-color: black;
+html, body {
+  min-height: 100vh;
+  font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  background-color: #000;
+  color: #f5f5f5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+.home {
+  background-color: #000;
   overflow: hidden;
+}
+
+.top-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 10;
+  background: rgba(18, 18, 18, 0.85);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.nav-links {
+  display: flex;
+  gap: 28px;
+  padding: 18px 36px;
+  align-items: center;
+}
+
+.nav-links a {
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: #f5f5f5;
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: #8fbcff;
 }
 
 /* Hero section */
@@ -19,6 +63,7 @@ body, html {
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+  padding-top: 72px;
 }
 
 .hero::after {
@@ -73,4 +118,113 @@ footer {
 .icons img {
   width: 60px;
   height: auto;
+}
+
+/* Notion-style content pages */
+body.notion {
+  background-color: #191919;
+  color: #e3e5e5;
+}
+
+.notion .top-nav {
+  background: rgba(24, 25, 26, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.notion-container {
+  max-width: 920px;
+  margin: 120px auto 96px;
+  padding: 0 32px 32px;
+}
+
+.notion-page-title {
+  font-size: 2.5rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.notion-page-subtitle {
+  font-size: 1.05rem;
+  color: #a6adbb;
+  margin-bottom: 32px;
+}
+
+.notion-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.notion-card h2 {
+  font-size: 1.35rem;
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+.notion-card p,
+.notion-card li {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: #d3d7e0;
+}
+
+.notion-card ul {
+  margin-left: 20px;
+  list-style: disc;
+}
+
+.notion-card ol {
+  margin-left: 20px;
+  list-style: decimal;
+}
+
+.notion-divider {
+  height: 1px;
+  background: linear-gradient(to right, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.04));
+  margin: 32px 0;
+}
+
+.notion-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.notion-pill {
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.95rem;
+  transition: background 0.2s ease, border 0.2s ease;
+}
+
+.notion-pill:hover,
+.notion-pill:focus {
+  background: rgba(143, 188, 255, 0.18);
+  border-color: rgba(143, 188, 255, 0.32);
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    gap: 16px;
+    padding: 16px 20px;
+    font-size: 0.9rem;
+  }
+
+  .notion-container {
+    margin: 108px auto 64px;
+    padding: 0 20px 24px;
+  }
+
+  .notion-page-title {
+    font-size: 2rem;
+  }
+
+  .notion-card {
+    padding: 20px;
+  }
 }


### PR DESCRIPTION
## Summary
- add a fixed navigation bar to the homepage for quick access to team resources
- restyle shared CSS and build notion-inspired layouts for secondary pages
- create dedicated Sponsors, Robots, Handbook, Join, and Contact pages with rich content

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dfecbd286483279c798fbf4527af56