### PR TITLE
Align subpage content with navigation bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,6 +124,7 @@ footer {
 body.notion {
   background-color: #191919;
   color: #e3e5e5;
+  padding-top: 72px;
 }
 
 .notion .top-nav {
@@ -133,8 +134,8 @@ body.notion {
 
 .notion-container {
   max-width: 920px;
-  margin: 120px auto 96px;
-  padding: 0 32px 32px;
+  margin: 0 auto 96px;
+  padding: 32px 32px;
 }
 
 .notion-page-title {
@@ -215,9 +216,13 @@ body.notion {
     font-size: 0.9rem;
   }
 
+  body.notion {
+    padding-top: 64px;
+  }
+
   .notion-container {
-    margin: 108px auto 64px;
-    padding: 0 20px 24px;
+    margin: 0 auto 64px;
+    padding: 24px 20px;
   }
 
   .notion-page-title {


### PR DESCRIPTION
## Summary
- add top padding on notion pages so content sits directly beneath the fixed navigation bar
- remove the large top margin on the notion container and tweak padding for desktop and mobile layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff12f3b288327837ee6af9229df80