### PR TITLE
Normalize footer icon bounding boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,9 +42,11 @@
         <img src="images/icon-robotics.png" alt="Robotics Logo">
       </a>
       <a href="https://www.thebluealliance.com/team/7028" target="_blank" rel="noopener noreferrer">
-      <img src="images/icon-bluealliance.png" alt="Blue Alliance Icon">
+        <img src="images/icon-bluealliance.png" alt="Blue Alliance Icon">
       </a>
-      <img src="images/icon-onshape.png" alt="Onshape Icon">
+      <span class="icon-wrapper">
+        <img src="images/icon-onshape.png" alt="Onshape Icon">
+      </span>
       <a href="https://github.com/stmarobotics" target="_blank" rel="noopener noreferrer">
         <img src="images/icon-github.png" alt="GitHub">
       </a>

--- a/style.css
+++ b/style.css
@@ -115,9 +115,20 @@ footer {
   gap: 40px;
 }
 
-.icons img {
+.icons a,
+.icons .icon-wrapper {
   width: 60px;
-  height: auto;
+  height: 60px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icons img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
 
 /* Notion-style content pages */


### PR DESCRIPTION
## Summary
- ensure each footer icon renders inside a uniform square container
- wrap the standalone Onshape image in a shared icon wrapper for consistent layout

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e00a4cad6883279dadf81401282a09