### PR TITLE
Update robots page with 2019-2025 season results

### DIFF
--- a/robots/index.html
+++ b/robots/index.html
@@ -21,29 +21,508 @@
     <h1 class="notion-page-title">Robots</h1>
     <p class="notion-page-subtitle">Season after season we prototype, design, and code machines that reflect our team values: curiosity, grit, and reliability.</p>
 
-    <section class="notion-card">
-      <h2>2024 &mdash; <em>Atlas</em></h2>
-      <p>Atlas is a swerve-drive robot engineered for precise positioning and rapid cycling. Dual intake rollers feed a telescoping arm capable of scoring in every grid tier.</p>
-      <ul>
-        <li>Subsystems: autonomous vision, articulated arm, dual-stage intake</li>
-        <li>Programming highlights: AprilTag localization, adaptive path planning</li>
-        <li>Notable award: Engineering Inspiration (Lake Superior Regional)</li>
-      </ul>
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2025 &mdash; <em>Torrent</em></h2>
+          <p class="robot-summary">Torrent&apos;s dynamic launcher and reliable climb pushed the team through an extended championship run.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Ben Wandmacher</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captains</h3>
+          <ul>
+            <li>Grace Kirk</li>
+            <li>Kylie Lukkar</li>
+            <li>Tatum Lallak</li>
+            <li>Will Spaulding</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Lake Superior Regional <span>Week 1</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>4-5 record &mdash; Rank 20/54</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #3 (1732, 7028, 8122) &mdash; 3-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Engineering Inspiration Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Granite City Regional <span>Week 6</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>8-2 record &mdash; Rank 4/48</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>#3 Alliance captain (7028, 7257, 7530) &mdash; 4-3</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Engineering Inspiration Award, Regional Finalists</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Curie Division &mdash; World Championship</h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>9-1 record &mdash; Rank 3/76</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>#3 Alliance captain (7028, 27, 3061, 2847) &mdash; 1-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>-</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Minnesota State High School League Championship</h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>6-1 record &mdash; Rank 6/36</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>#3 Alliance captain (7028, 2491, 4728) &mdash; 1-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>-</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2024 &mdash; <em>Tempo</em></h2>
+          <p class="robot-summary">Tempo&apos;s fast cycler and consistent endgame powered deep playoff runs at every event.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kelly Willette</li>
+            <li>Kris Rue</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captains</h3>
+          <ul>
+            <li>Dylan Rattai</li>
+            <li>Sydney Gasser</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Great Northern Regional <span>Week 2</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>3-6 record &mdash; Rank 45/56</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #4 (4198, 7028, 2508) &mdash; 0-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Autonomous Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Granite City Regional <span>Week 5</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>9-1 record &mdash; Rank 3/54</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>#1 Alliance (3276, 7028, 6045) &mdash; 5-0</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Regional Winners, Team Sustainability Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Curie Division &mdash; World Championship</h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>7-3 record &mdash; Rank 20/74</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>2nd pick of alliance #8 (2590, 4476, 7028, 190) &mdash; 6-1</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Championship Division Winner</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="event-block">
+        <h3>Einstein Field &mdash; World Championship</h3>
+        <table class="match-table">
+          <thead>
+            <tr>
+              <th>Match</th>
+              <th>Curie Alliance</th>
+              <th>Opposing Alliance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Match 3</td>
+              <td>2590 &middot; 7028 &middot; 4476 &middot; 9483</td>
+              <td>604 &middot; 78 &middot; 138 &middot; 148</td>
+            </tr>
+            <tr>
+              <td>Match 6</td>
+              <td>2590 &middot; 7028 &middot; 4476 &middot; 5813</td>
+              <td>1477 &middot; 3061 &middot; 141 &middot; 140</td>
+            </tr>
+            <tr>
+              <td>Match 9</td>
+              <td>4476 &middot; 7028 &middot; 2590 &middot; 125</td>
+              <td>6328 &middot; 9072 &middot; 4481 &middot; 119</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2023 &mdash; <em>Orion</em></h2>
+          <p class="robot-summary">Orion&apos;s lighting-fast cube and cone handling helped secure control awards and deep runs across Minnesota.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kris Rue</li>
+            <li>Roger Bovee</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captain</h3>
+          <ul>
+            <li>Audie Wadmacher</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Great Northern Regional <span>Week 2</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>9-1 record &mdash; Rank 3/53</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>Captain of alliance #2 (7028, 876, 3630) &mdash; 1-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Innovation in Control Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Minnesota North Star Regional <span>Week 4</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>7-6 record &mdash; Rank 16/39</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #7 (3082, 7028, 4198) &mdash; 2-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Autonomous Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="event-block">
+        <h3>Minnesota State Championship &mdash; MSHSL</h3>
+        <table class="event-table">
+          <tbody>
+            <tr>
+              <th>Qualifications</th>
+              <td>2-6 record &mdash; Rank 30/36</td>
+            </tr>
+            <tr>
+              <th>Playoffs</th>
+              <td>-</td>
+            </tr>
+            <tr>
+              <th>Awards</th>
+              <td>-</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2022 &mdash; <em>Onyx</em></h2>
+          <p class="robot-summary">Onyx balanced high-difficulty auton routines with a battle-tested teleop cycle for consistent finalist appearances.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kris Rue</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captain</h3>
+          <ul>
+            <li>Matthew Bartos</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Great Northern Regional <span>Week 4</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>7-3 record &mdash; Rank 4/49</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #2 (5913, 7028, 2508) &mdash; 1-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Innovation in Control Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Minnesota 10,000 Lakes Regional <span>Week 6</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>8-2 record &mdash; Rank 3/55</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #2 (2052, 7028, 3082) &mdash; 5-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Regional Finalists, Autonomous Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="event-block">
+        <h3>Minnesota State Championship &mdash; MSHSL</h3>
+        <table class="event-table">
+          <tbody>
+            <tr>
+              <th>Qualifications</th>
+              <td>4-4 record &mdash; Rank 11/36</td>
+            </tr>
+            <tr>
+              <th>Playoffs</th>
+              <td>1st pick of alliance #4 (2502, 7028, 2883) &mdash; 0-2</td>
+            </tr>
+            <tr>
+              <th>Awards</th>
+              <td>-</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2020 &mdash; <em>Wilson</em></h2>
+          <p class="robot-summary">Wilson delivered rapid power cell cycling before the season came to an early close.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kris Rue</li>
+            <li>Roger Bovee</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captain</h3>
+          <ul>
+            <li>Sam Draeger</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-block">
+        <h3>Great Northern Regional <span>Week 1</span></h3>
+        <table class="event-table">
+          <tbody>
+            <tr>
+              <th>Qualifications</th>
+              <td>6-3 record &mdash; Rank 13/60</td>
+            </tr>
+            <tr>
+              <th>Playoffs</th>
+              <td>1st pick of alliance #7 (4539, 7028, 3297) &mdash; 0-2</td>
+            </tr>
+            <tr>
+              <th>Awards</th>
+              <td>-</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <div class="robot-header">
+        <div>
+          <h2>2019 &mdash; <em>Ozzy</em></h2>
+          <p class="robot-summary">Ozzy&apos;s climber and hatch manipulator kept the team in contention throughout Deep Space.</p>
+        </div>
+      </div>
+      <div class="robot-meta">
+        <div>
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kris Rue</li>
+            <li>Roger Bovee</li>
+            <li>Zack Osowski</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Captain</h3>
+          <ul>
+            <li>Wyatt McKarthy</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Northern Lights Regional <span>Week 2</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>5-3-1 record &mdash; Rank 11/60</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+              <td>1st pick of alliance #5 (6132, 7028, 4593) &mdash; 1-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>-</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Minnesota 10,000 Lakes Regional <span>Week 5</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>7-2 record &mdash; Rank 5/63</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>1st pick of alliance #2 (2987, 7028, 4536) &mdash; 2-3</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Creativity Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </section>
 
     <section class="notion-card">
-      <h2>2023 &mdash; <em>Nova</em></h2>
-      <p>Nova featured a tank drive base with a focus on consistency. A pneumatic elevator and pivoting cube manipulator provided dependable scoring throughout the season.</p>
-      <ul>
-        <li>Subsystems: dual-speed gearbox, elevator, cube claw</li>
-        <li>Programming highlights: auto balance routine, driver assist macros</li>
-        <li>Notable award: Innovation in Control (Minnesota State Championship)</li>
-      </ul>
-    </section>
-
-    <section class="notion-card">
-      <h2>Earlier Seasons</h2>
-      <p>Explore a gallery of our past designs, prototypes, and off-season projects that paved the way for today&apos;s robots.</p>
+      <h2>More History</h2>
+      <p>Explore past designs, prototypes, and off-season projects that paved the way for today&apos;s robots.</p>
       <div class="notion-links">
         <a class="notion-pill" href="https://www.thebluealliance.com/team/7028" target="_blank" rel="noopener noreferrer">Season history on The Blue Alliance</a>
         <a class="notion-pill" href="https://github.com/stmarobotics" target="_blank" rel="noopener noreferrer">Code repositories</a>

--- a/style.css
+++ b/style.css
@@ -170,6 +170,141 @@ body.notion {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
+.robot-card + .robot-card {
+  margin-top: 32px;
+}
+
+.robot-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 16px;
+}
+
+.robot-summary {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #b0b7c6;
+  margin-top: 6px;
+}
+
+.robot-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  margin-bottom: 16px;
+}
+
+.robot-meta h3 {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8ba0c6;
+  margin-bottom: 6px;
+}
+
+.robot-meta ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.robot-meta li {
+  font-size: 0.95rem;
+  color: #dce1eb;
+}
+
+.event-grid {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.event-block {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.event-block h3 {
+  font-size: 1.05rem;
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.event-block h3 span {
+  font-size: 0.85rem;
+  color: #8f9db7;
+}
+
+.event-table,
+.match-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.event-table th,
+.event-table td,
+.match-table th,
+.match-table td {
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  vertical-align: top;
+  font-size: 0.95rem;
+  color: #d7dbe7;
+}
+
+.match-table th {
+  text-align: left;
+}
+
+.event-table th {
+  width: 140px;
+  font-weight: 600;
+  color: #9fb0ce;
+  padding-right: 12px;
+}
+
+.event-table tr:last-child th,
+.event-table tr:last-child td,
+.match-table tr:last-child td,
+.match-table tr:last-child th {
+  border-bottom: none;
+}
+
+.match-table {
+  margin-top: 8px;
+}
+
+.match-table thead th {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: #8f9db7;
+}
+
+.match-table tbody tr td:first-child {
+  font-weight: 600;
+  color: #b7c4df;
+}
+
+.match-table tbody td {
+  font-family: 'Fira Code', 'Roboto Mono', monospace;
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.event-block + .event-block {
+  margin-top: 0;
+}
+
 .notion-card h2 {
   font-size: 1.35rem;
   margin-bottom: 12px;


### PR DESCRIPTION
## Summary
- replace the robots page with detailed season cards for 2019-2025
- add tables summarizing event records, alliance partners, and awards from the provided images
- expand the site stylesheet with layout and table styles for the new robot history content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03602c73483278ce66275f8e5d774