### PR TITLE
Ensure home animations wait for image load

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Binary Battalion 7028</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="preload" href="images/7028-hero.jpg" as="image">
+  <link rel="preload" href="images/7028-logo.png" as="image">
 </head>
 <body class="home">
   <nav class="top-nav">
@@ -52,5 +54,31 @@
       </a>
     </div>
   </footer>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const body = document.body;
+      if (!body.classList.contains('home')) {
+        return;
+      }
+
+      const images = Array.from(document.querySelectorAll('.hero img, footer img'));
+
+      const whenImageReady = (img) => {
+        if (img.complete && img.naturalWidth !== 0) {
+          return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+          const finalize = () => resolve();
+          img.addEventListener('load', finalize, { once: true });
+          img.addEventListener('error', finalize, { once: true });
+        });
+      };
+
+      Promise.all(images.map(whenImageReady)).then(() => {
+        requestAnimationFrame(() => body.classList.add('animations-ready'));
+      });
+    });
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -84,6 +84,8 @@ a:hover {
   object-fit: cover;
   object-position: top;
   z-index: 0;
+  opacity: 1;
+  transition: opacity 0.6s ease;
 }
 
 /* Logo in center */
@@ -189,6 +191,16 @@ footer {
 
 .icons > *:nth-child(7) {
   animation-delay: 1.12s;
+}
+
+.home:not(.animations-ready) .hero .background {
+  opacity: 0;
+}
+
+.home:not(.animations-ready) .logo-container img,
+.home:not(.animations-ready) .icons a,
+.home:not(.animations-ready) .icons .icon-wrapper {
+  animation-play-state: paused;
 }
 
 /* Notion-style content pages */


### PR DESCRIPTION
## Summary
- preload the hero and logo assets to start fetching them immediately
- wait for the hero and footer imagery to finish loading before starting animations
- fade in the hero background once assets are ready to avoid flicker

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e169adc8e8832791bd347ec0e57f67