### PR TITLE
Add robot photos to robots page

### DIFF
--- a/robots/index.html
+++ b/robots/index.html
@@ -23,6 +23,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-torrent.JPG" alt="Torrent robot" loading="lazy">
         <div>
           <h2>2025 &mdash; <em>Torrent</em></h2>
           <p class="robot-summary">Torrent&apos;s dynamic launcher and reliable climb pushed the team through an extended championship run.</p>
@@ -130,6 +131,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-tempo.JPG" alt="Tempo robot" loading="lazy">
         <div>
           <h2>2024 &mdash; <em>Tempo</em></h2>
           <p class="robot-summary">Tempo&apos;s fast cycler and consistent endgame powered deep playoff runs at every event.</p>
@@ -246,6 +248,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-orion.JPG" alt="Orion robot" loading="lazy">
         <div>
           <h2>2023 &mdash; <em>Orion</em></h2>
           <p class="robot-summary">Orion&apos;s lighting-fast cube and cone handling helped secure control awards and deep runs across Minnesota.</p>
@@ -330,6 +333,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-onyx.JPG" alt="Onyx robot" loading="lazy">
         <div>
           <h2>2022 &mdash; <em>Onyx</em></h2>
           <p class="robot-summary">Onyx balanced high-difficulty auton routines with a battle-tested teleop cycle for consistent finalist appearances.</p>
@@ -413,6 +417,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-wilson.jpg" alt="Wilson robot" loading="lazy">
         <div>
           <h2>2020 &mdash; <em>Wilson</em></h2>
           <p class="robot-summary">Wilson delivered rapid power cell cycling before the season came to an early close.</p>
@@ -457,6 +462,7 @@
 
     <section class="notion-card robot-card">
       <div class="robot-header">
+        <img class="robot-photo" src="/images/robot-ozzy.jpg" alt="Ozzy robot" loading="lazy">
         <div>
           <h2>2019 &mdash; <em>Ozzy</em></h2>
           <p class="robot-summary">Ozzy&apos;s climber and hatch manipulator kept the team in contention throughout Deep Space.</p>

--- a/style.css
+++ b/style.css
@@ -256,6 +256,16 @@ body.notion {
   margin-bottom: 16px;
 }
 
+.robot-photo {
+  flex: 0 0 280px;
+  width: min(280px, 100%);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  object-fit: cover;
+  aspect-ratio: 4 / 3;
+}
+
 .robot-summary {
   font-size: 1rem;
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- display newly added robot photos alongside each robot entry on the robots page
- style robot images to fit the existing Notion-inspired layout with consistent framing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1731089748327b03c3efaf4dd39da