### PR TITLE
Add 2018 robot entry and update 2019 achievements

### DIFF
--- a/robots/index.html
+++ b/robots/index.html
@@ -501,7 +501,7 @@
             <span class="robot-season">2019</span>
             <span class="robot-name">Ozzy</span>
           </h2>
-          <p class="robot-summary">Ozzy&apos;s climber and hatch manipulator kept the team in contention throughout Deep Space.</p>
+          <p class="robot-summary">Ozzy combined a dependable level-three climb with consistent scoring to headline a banner Deep Space season.</p>
         </div>
       </header>
       <div class="robot-meta">
@@ -531,7 +531,7 @@
               </tr>
               <tr>
                 <th>Playoffs</th>
-              <td>1st pick of alliance #5 (6132, 7028, 4593) &mdash; 1-2</td>
+                <td>1st pick of alliance #5 (6132, 7028, 4593) &mdash; 1-2</td>
               </tr>
               <tr>
                 <th>Awards</th>
@@ -555,6 +555,96 @@
               <tr>
                 <th>Awards</th>
                 <td>Creativity Award</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Minnesota State Championship <span>MSHSL</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>6-3 record &mdash; Rank 3/36</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>Captain of alliance #3 (7028, 4607, 1816) &mdash; 0-2</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>-</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="notion-card robot-card">
+      <header class="robot-header">
+        <figure class="robot-media">
+          <img class="robot-photo" src="/images/robot-phyllis.JPG" alt="Phyllis robot" loading="lazy">
+        </figure>
+        <div class="robot-overview">
+          <p class="robot-season-label">POWER UP</p>
+          <h2 class="robot-title">
+            <span class="robot-season">2018</span>
+            <span class="robot-name">Phyllis</span>
+          </h2>
+          <p class="robot-summary">Phyllis launched Team 7028 into FRC with reliable scale play that earned top rookie honors.</p>
+        </div>
+      </header>
+      <div class="robot-meta">
+        <div class="robot-meta-group">
+          <h3>Coaches</h3>
+          <ul>
+            <li>Kris Rue</li>
+            <li>Roger Bovee</li>
+          </ul>
+        </div>
+        <div class="robot-meta-group">
+          <h3>Captain</h3>
+          <ul>
+            <li>Wyatt McKarthy</li>
+          </ul>
+        </div>
+      </div>
+      <div class="event-grid">
+        <div class="event-block">
+          <h3>Lake Superior Regional <span>Week 2</span></h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>3-6 record &mdash; Rank 41/62</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>-</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>Rookie All Star Award, Highest Rookie Seed</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="event-block">
+          <h3>Carson Division &mdash; World Championship</h3>
+          <table class="event-table">
+            <tbody>
+              <tr>
+                <th>Qualifications</th>
+                <td>4-6 record &mdash; Rank 57/68</td>
+              </tr>
+              <tr>
+                <th>Playoffs</th>
+                <td>-</td>
+              </tr>
+              <tr>
+                <th>Awards</th>
+                <td>-</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
## Summary
- refresh the 2019 Ozzy card with expanded Deep Space event results and season summary
- add a new 2018 Phyllis robot card with coaches, captain, and event performance details

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3118687dc8327a0573028bf41835c