### PR TITLE
Add 2024 Einstein match scores to robots page

### DIFF
--- a/robots/index.html
+++ b/robots/index.html
@@ -229,9 +229,15 @@
         <table class="match-table">
           <thead>
             <tr>
-              <th>Match</th>
-              <th>Curie Alliance</th>
-              <th>Opposing Alliance</th>
+              <th rowspan="2" scope="col">Match</th>
+              <th colspan="2" scope="colgroup" class="group-heading">Einstein Field</th>
+              <th colspan="2" scope="colgroup" class="group-heading">World Championship</th>
+            </tr>
+            <tr>
+              <th scope="col">Curie Alliance</th>
+              <th scope="col">Opposing Alliance</th>
+              <th scope="col">Curie Score</th>
+              <th scope="col">Opposing Score</th>
             </tr>
           </thead>
           <tbody>
@@ -239,16 +245,22 @@
               <td>Match 3</td>
               <td>2590 &middot; 7028 &middot; 4476 &middot; 9483</td>
               <td>604 &middot; 78 &middot; 138 &middot; 148</td>
+              <td class="match-score">138</td>
+              <td class="match-score">148</td>
             </tr>
             <tr>
               <td>Match 6</td>
               <td>2590 &middot; 7028 &middot; 4476 &middot; 5813</td>
               <td>1477 &middot; 3061 &middot; 141 &middot; 140</td>
+              <td class="match-score">141</td>
+              <td class="match-score">140</td>
             </tr>
             <tr>
               <td>Match 9</td>
               <td>4476 &middot; 7028 &middot; 2590 &middot; 125</td>
               <td>6328 &middot; 9072 &middot; 4481 &middot; 119</td>
+              <td class="match-score">125</td>
+              <td class="match-score">119</td>
             </tr>
           </tbody>
         </table>

--- a/style.css
+++ b/style.css
@@ -458,6 +458,10 @@ body.notion {
   color: #8f9db7;
 }
 
+.match-table .group-heading {
+  text-align: center;
+}
+
 .match-table tbody tr td:first-child {
   font-weight: 600;
   color: #b7c4df;
@@ -467,6 +471,12 @@ body.notion {
   font-family: 'Fira Code', 'Roboto Mono', monospace;
   font-size: 0.9rem;
   word-break: break-word;
+}
+
+.match-table .match-score {
+  text-align: center;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .event-block + .event-block {


### PR DESCRIPTION
## Summary
- add Einstein Field score columns to the 2024 world championship match table
- include styling to center the new score headers and values

## Testing
- python3 -m http.server 8000 (manual verification)

------
https://chatgpt.com/codex/tasks/task_e_68e3140b14688327a4b5c57953caa975