### PR TITLE
Add Konami code easter egg for home logo spin

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,67 @@
 
       const images = Array.from(document.querySelectorAll('.hero img, footer img'));
 
+      const logoContainer = document.querySelector('.logo-container');
+      const konamiSequence = [
+        'ArrowUp',
+        'ArrowUp',
+        'ArrowDown',
+        'ArrowDown',
+        'ArrowLeft',
+        'ArrowRight',
+        'ArrowLeft',
+        'ArrowRight',
+        'b',
+        'a',
+        'Enter'
+      ];
+      let konamiIndex = 0;
+
+      const normalizeKey = (key) => {
+        if (key.startsWith('Arrow')) {
+          return key;
+        }
+
+        if (key === 'Enter') {
+          return key;
+        }
+
+        return key.length === 1 ? key.toLowerCase() : key;
+      };
+
+      const triggerLogoSpin = () => {
+        if (!logoContainer || logoContainer.classList.contains('konami-spinning')) {
+          return;
+        }
+
+        logoContainer.classList.add('konami-spinning');
+        logoContainer.addEventListener(
+          'animationend',
+          () => {
+            logoContainer.classList.remove('konami-spinning');
+          },
+          { once: true }
+        );
+      };
+
+      document.addEventListener('keydown', (event) => {
+        const normalizedKey = normalizeKey(event.key);
+        const expectedKey = konamiSequence[konamiIndex];
+
+        if (normalizedKey === expectedKey) {
+          konamiIndex += 1;
+
+          if (konamiIndex === konamiSequence.length) {
+            triggerLogoSpin();
+            konamiIndex = 0;
+          }
+
+          return;
+        }
+
+        konamiIndex = normalizedKey === konamiSequence[0] ? 1 : 0;
+      });
+
       const whenImageReady = (img) => {
         if (img.complete && img.naturalWidth !== 0) {
           return Promise.resolve();

--- a/style.css
+++ b/style.css
@@ -97,6 +97,10 @@ a:hover {
   z-index: 2;
 }
 
+.logo-container.konami-spinning {
+  animation: konamiSpin 1.8s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
 .logo-container img {
   width: clamp(180px, 30vw, 420px);
   height: auto;
@@ -104,6 +108,24 @@ a:hover {
   transform: translateY(32px) scale(0.88);
   animation: logoEntry 1.6s ease-out 0.4s forwards;
   animation-fill-mode: both;
+}
+
+@keyframes konamiSpin {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg) scale(1);
+  }
+  20% {
+    transform: translate(-50%, -50%) rotate(-25deg) scale(1.05);
+  }
+  50% {
+    transform: translate(-50%, -50%) rotate(360deg) scale(1.12);
+  }
+  75% {
+    transform: translate(-50%, -50%) rotate(540deg) scale(0.92);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(720deg) scale(1);
+  }
 }
 
 @keyframes logoEntry {


### PR DESCRIPTION
## Summary
- add a Konami code listener on the home page that watches for the up, up, down, down, left, right, left, right, b, a, enter sequence
- trigger a playful spin animation on the centered logo when the sequence completes
- style the new animation with a multi-rotation keyframe sequence and automatic cleanup so it can be triggered repeatedly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3c4248f04832784a9eac1f9e89e94