### PR TITLE
Restore hero-only homepage layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     }
   </script>
 </head>
-<body class="home home-with-content">
+<body class="home">
   <nav class="top-nav" aria-label="Primary navigation">
     <div class="nav-links">
       <a href="/sponsors/">Sponsors</a>
@@ -86,64 +86,6 @@
       <img src="images/7028-logo.png" alt="Binary Battalion Team Logo">
     </div>
   </div>
-
-  <main class="home-content" id="about">
-    <section class="home-content__intro">
-      <h1>FRC 7028 Binary Battalion Robotics in St. Michael-Albertville, Minnesota</h1>
-      <p>
-        Binary Battalion is FIRST Robotics Competition Team 7028 from St. Michael-Albertville High School in Central Minnesota.
-        We empower students to design, fabricate, and program competitive robots while building leadership, outreach, and STEM
-        confidence across the communities of St. Michael, Albertville, Otsego, and beyond.
-      </p>
-      <p>
-        Our recent cone-shooting robot builds have delivered top-tier performance at the <strong>Granite City Regional</strong>,
-        <strong>Lake Superior Regional</strong>, and the <strong>FIRST Championship</strong>. From autonomous innovation to
-        award-winning strategy, Binary Battalion continues to represent Minnesota robotics on and off the field.
-      </p>
-    </section>
-
-    <section class="home-content__grid" aria-label="Team highlights">
-      <article class="home-content__card">
-        <h2>Why Central Minnesota Students Choose FRC 7028</h2>
-        <ul>
-          <li>Inclusive robotics experience for St. Michael-Albertville and surrounding schools.</li>
-          <li>Hands-on training in CAD, machining, programming, and data-driven match scouting.</li>
-          <li>Experienced mentors guiding students toward college, engineering, and STEM careers.</li>
-        </ul>
-      </article>
-      <article class="home-content__card">
-        <h2>Signature Robot Capabilities</h2>
-        <p>
-          Binary Battalion&apos;s robots feature precision cone acquisition and shooting systems, fast swerve drive navigation,
-          and autonomous routines tuned for Central and Northern Minnesota regionals. Explore how <strong>FRC Binary Battalion</strong>
-          maximizes scoring in every FIRST Robotics Competition season.
-        </p>
-      </article>
-      <article class="home-content__card">
-        <h2>Get Involved</h2>
-        <p>
-          Prospective students, mentors, and sponsors can connect with us to support <strong>STMA Robotics</strong>. Learn how to
-          join the team, collaborate on STEM outreach, or partner with <strong>FRC Team 7028 Binary Battalion</strong> as we continue
-          to elevate Minnesota robotics.
-        </p>
-        <div class="home-content__links">
-          <a class="home-content__link" href="/join/">Join Binary Battalion</a>
-          <a class="home-content__link" href="/contact/">Contact Coaches</a>
-          <a class="home-content__link" href="/robots/">See Our Robots</a>
-        </div>
-      </article>
-    </section>
-
-    <section class="home-content__cta">
-      <h2>Looking for Minnesota or Central Minnesota Robotics?</h2>
-      <p>
-        Search for <em>7028</em>, <em>FRC 7028 Binary Battalion</em>, <em>STMA Robotics</em>, <em>St Michael robotics</em>, or
-        <em>Albertville robotics</em> and you&apos;ll find Binary Battalion ready to collaborate. We regularly host STEM showcases,
-        volunteer events, and build season tours for families exploring <em>FIRST Robotics 7028</em>, <em>First Robotics St Michael</em>,
-        and innovation across Central Minnesota.
-      </p>
-    </section>
-  </main>
 
   <!-- Footer with icons -->
   <footer>

--- a/style.css
+++ b/style.css
@@ -26,10 +26,6 @@ a:hover {
   overflow: hidden;
 }
 
-.home-with-content {
-  overflow: visible;
-}
-
 .top-nav {
   position: fixed;
   top: 0;
@@ -69,10 +65,6 @@ a:hover {
   height: 100vh;
   overflow: hidden;
   padding-top: 72px;
-}
-
-.home-with-content .hero {
-  height: min(100vh, 720px);
 }
 
 .hero::after {
@@ -151,139 +143,13 @@ a:hover {
   }
 }
 
-/* Home content */
-.home-content {
-  position: relative;
-  z-index: 3;
-  padding: 80px 24px 64px;
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 1) 30%, rgba(0, 0, 0, 1) 100%);
-  color: #f5f5f5;
-}
-
-.home-content__intro {
-  max-width: 960px;
-  margin: 0 auto 64px auto;
-  text-align: left;
-}
-
-.home-content__intro h1 {
-  font-size: clamp(2.25rem, 3vw + 1rem, 3.5rem);
-  margin-bottom: 20px;
-  line-height: 1.15;
-}
-
-.home-content__intro p {
-  font-size: 1.1rem;
-  line-height: 1.7;
-  margin-bottom: 16px;
-  color: rgba(245, 245, 245, 0.92);
-}
-
-.home-content__grid {
-  display: grid;
-  gap: 32px;
-  margin-bottom: 64px;
-}
-
-.home-content__card {
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 18px;
-  padding: 28px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.4);
-}
-
-.home-content__card h2 {
-  font-size: 1.6rem;
-  margin-bottom: 18px;
-}
-
-.home-content__card p,
-.home-content__card li {
-  font-size: 1.05rem;
-  line-height: 1.7;
-  color: rgba(236, 241, 255, 0.9);
-}
-
-.home-content__card ul {
-  padding-left: 20px;
-  display: grid;
-  gap: 12px;
-}
-
-.home-content__links {
-  margin-top: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-}
-
-.home-content__link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 12px 20px;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(37, 99, 235, 0.1);
-  color: #cfe1ff;
-  font-weight: 600;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.home-content__link:hover,
-.home-content__link:focus {
-  background: rgba(37, 99, 235, 0.25);
-  border-color: rgba(96, 165, 250, 0.6);
-  color: #ffffff;
-}
-
-.home-content__cta {
-  max-width: 820px;
-  margin: 0 auto;
-  text-align: center;
-  padding: 48px 36px;
-  border-radius: 20px;
-  background: rgba(12, 74, 110, 0.35);
-  border: 1px solid rgba(94, 234, 212, 0.2);
-  box-shadow: 0 20px 40px rgba(12, 74, 110, 0.35);
-}
-
-.home-content__cta h2 {
-  font-size: clamp(1.9rem, 1.8vw + 1rem, 2.5rem);
-  margin-bottom: 16px;
-}
-
-.home-content__cta p {
-  font-size: 1.1rem;
-  line-height: 1.7;
-  color: rgba(224, 242, 254, 0.92);
-}
-
-@media (min-width: 768px) {
-  .home-content {
-    padding: 110px 48px 96px;
-  }
-
-  .home-content__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 767px) {
-  .home-content__grid {
-    grid-template-columns: 1fr;
-  }
-}
-
 /* Footer with icons */
 footer {
-  position: static;
+  position: absolute;
+  bottom: 30px;
   width: 100%;
   text-align: center;
   z-index: 2;
-  padding: 48px 24px 64px;
-  background: #000;
 }
 
 .icons {


### PR DESCRIPTION
## Summary
- remove the additional content sections from the homepage so it returns to the hero-only layout
- clean up the related CSS so the page fills the viewport without introducing scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e61fe0288327acce9d3f3f15eb18