### PR TITLE
Refactor navigation into shared partials and add site footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,18 +6,10 @@
   <title>No Robot Connection | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="error-page">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="error-container">
     <section class="error-card">
@@ -25,5 +17,6 @@
       <h1>No Robot Connection</h1>
     </section>
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -6,18 +6,10 @@
   <title>Contact | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="notion">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="notion-container">
     <h1 class="notion-page-title">Contact</h1>
@@ -38,5 +30,6 @@
     </section>
 
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/handbook/index.html
+++ b/handbook/index.html
@@ -6,18 +6,10 @@
   <title>Handbook | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="notion">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="notion-container">
     <h1 class="notion-page-title">Team Handbook</h1>
@@ -100,5 +92,6 @@
       <p>Mentors are here to bring out the best in our students through inspiration, education, collaboration, and demonstration. That statement can be interpreted in many different ways, but it really depends on the circumstance. Mentors completing tasks should never be prioritized over students completing those same tasks, but sometimes they need to fill in the gaps. It is totally normal and encouraged for mentors to work on a project alongside our students, whether that be helping turn a wrench, solder a wire, write some code, contribute ideas to discussions, or design a part. Your mentors are not passive observers and they are not your bosses. They are your partners in achieving your goals.</p>
     </section>
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,17 +8,10 @@
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
   <link rel="preload" href="images/7028-hero.jpg" as="image">
   <link rel="preload" href="images/7028-logo.png" as="image">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="home">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
   <!-- Background team photo -->
   <div class="hero">
     <img src="images/7028-hero.jpg" alt="Team Photo" class="background">
@@ -29,34 +22,9 @@
     </div>
   </div>
 
-  <!-- Footer with icons -->
-  <footer>
-    <div class="icons">
-      <a href="https://www.instagram.com/7028_robotics/" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-instagram.png" alt="Instagram">
-      </a>
-      <a href="https://www.youtube.com/@7028robotics" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-youtube.png" alt="YouTube">
-      </a>
-      <a href="https://www.facebook.com/STMARobotics/" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-facebook.png" alt="Facebook">
-      </a>
-      <a href="https://www.stmarobotics.org/" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-robotics.png" alt="Robotics Logo">
-      </a>
-      <a href="https://www.thebluealliance.com/team/7028" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-bluealliance.png" alt="Blue Alliance Icon">
-      </a>
-      <span class="icon-wrapper">
-        <img src="images/icon-onshape.png" alt="Onshape Icon">
-      </span>
-      <a href="https://github.com/stmarobotics" target="_blank" rel="noopener noreferrer">
-        <img src="images/icon-github.png" alt="GitHub">
-      </a>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
   <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    const initializeHomePage = () => {
       const body = document.body;
       if (!body.classList.contains('home')) {
         return;
@@ -81,11 +49,7 @@
       let konamiIndex = 0;
 
       const normalizeKey = (key) => {
-        if (key.startsWith('Arrow')) {
-          return key;
-        }
-
-        if (key === 'Enter') {
+        if (key.startsWith('Arrow') || key === 'Enter') {
           return key;
         }
 
@@ -140,7 +104,13 @@
       Promise.all(images.map(whenImageReady)).then(() => {
         requestAnimationFrame(() => body.classList.add('animations-ready'));
       });
-    });
+    };
+
+    if (window.__includesLoaded) {
+      initializeHomePage();
+    } else {
+      document.addEventListener('includesLoaded', initializeHomePage, { once: true });
+    }
   </script>
 </body>
 </html>

--- a/join/index.html
+++ b/join/index.html
@@ -6,18 +6,10 @@
   <title>Join | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="notion">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="notion-container">
     <h1 class="notion-page-title">Join 7028</h1>
@@ -38,5 +30,6 @@
     </section>
 
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,31 @@
+<footer class="site-footer">
+  <div class="footer-inner">
+    <div class="footer-meta">
+      <p class="footer-title">Binary Battalion 7028</p>
+      <p class="footer-copy">© 2005 Binary Battalion</p>
+    </div>
+    <div class="footer-icons icons">
+      <a href="https://www.instagram.com/7028_robotics/" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-instagram.png" alt="Instagram">
+      </a>
+      <a href="https://www.youtube.com/@7028robotics" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-youtube.png" alt="YouTube">
+      </a>
+      <a href="https://www.facebook.com/STMARobotics/" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-facebook.png" alt="Facebook">
+      </a>
+      <a href="https://www.stmarobotics.org/" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-robotics.png" alt="Robotics Logo">
+      </a>
+      <a href="https://www.thebluealliance.com/team/7028" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-bluealliance.png" alt="Blue Alliance">
+      </a>
+      <span class="icon-wrapper">
+        <img src="/images/icon-onshape.png" alt="Onshape">
+      </span>
+      <a href="https://github.com/stmarobotics" target="_blank" rel="noopener noreferrer">
+        <img src="/images/icon-github.png" alt="GitHub">
+      </a>
+    </div>
+  </div>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,10 @@
+<nav class="top-nav">
+  <div class="nav-links">
+    <a href="/">Home</a>
+    <a href="/sponsors/">Sponsors</a>
+    <a href="/robots/">Robots</a>
+    <a href="/handbook/">Handbook</a>
+    <a href="/join/">Join</a>
+    <a href="/contact/">Contact</a>
+  </div>
+</nav>

--- a/robots/index.html
+++ b/robots/index.html
@@ -6,18 +6,10 @@
   <title>Robots | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="notion">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="notion-container">
     <h1 class="notion-page-title">Robots</h1>
@@ -658,5 +650,6 @@
       </div>
     </section>
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/scripts/include.js
+++ b/scripts/include.js
@@ -1,0 +1,54 @@
+(() => {
+  const INCLUDE_ATTRIBUTE = 'data-include';
+
+  const loadInclude = async (placeholder) => {
+    const path = placeholder.getAttribute(INCLUDE_ATTRIBUTE);
+
+    if (!path) {
+      return;
+    }
+
+    try {
+      const response = await fetch(path);
+
+      if (!response.ok) {
+        throw new Error(`Failed to load include: ${path} (${response.status})`);
+      }
+
+      const markup = await response.text();
+      const template = document.createElement('template');
+      template.innerHTML = markup.trim();
+
+      const fragment = template.content.cloneNode(true);
+      placeholder.replaceWith(fragment);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const notifyLoaded = () => {
+    window.__includesLoaded = true;
+    document.dispatchEvent(new CustomEvent('includesLoaded'));
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      const placeholders = document.querySelectorAll(`[${INCLUDE_ATTRIBUTE}]`);
+      if (!placeholders.length) {
+        notifyLoaded();
+        return;
+      }
+
+      Promise.all(Array.from(placeholders, loadInclude)).finally(notifyLoaded);
+    });
+    return;
+  }
+
+  const placeholders = document.querySelectorAll(`[${INCLUDE_ATTRIBUTE}]`);
+  if (!placeholders.length) {
+    notifyLoaded();
+    return;
+  }
+
+  Promise.all(Array.from(placeholders, loadInclude)).finally(notifyLoaded);
+})();

--- a/sponsors/index.html
+++ b/sponsors/index.html
@@ -6,22 +6,15 @@
   <title>Sponsors | Binary Battalion 7028</title>
   <link rel="stylesheet" href="/style.css">
   <link rel="icon" href="/images/favicon.webp" type="image/webp">
+  <script src="/scripts/include.js" defer></script>
 </head>
 <body class="notion">
-  <nav class="top-nav">
-    <div class="nav-links">
-      <a href="/">Home</a>
-      <a href="/sponsors/">Sponsors</a>
-      <a href="/robots/">Robots</a>
-      <a href="/handbook/">Handbook</a>
-      <a href="/join/">Join</a>
-      <a href="/contact/">Contact</a>
-    </div>
-  </nav>
+  <div data-include="/partials/header.html"></div>
 
   <main class="notion-container">
     <h1 class="notion-page-title">Sponsors</h1>
     <p class="notion-page-subtitle">This page is under construction</p>
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -143,13 +143,48 @@ a:hover {
   }
 }
 
-/* Footer with icons */
-footer {
-  position: absolute;
-  bottom: 30px;
-  width: 100%;
-  text-align: center;
-  z-index: 2;
+/* Footer */
+.site-footer {
+  margin-top: clamp(72px, 12vw, 128px);
+  padding: 48px 24px;
+  background: linear-gradient(180deg, rgba(10, 14, 24, 0.92), rgba(6, 9, 16, 0.95));
+  border-top: 1px solid rgba(143, 188, 255, 0.14);
+}
+
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.footer-meta {
+  display: grid;
+  gap: 8px;
+  color: rgba(219, 228, 255, 0.92);
+}
+
+.footer-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.footer-copy {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(166, 187, 226, 0.82);
+}
+
+.footer-icons {
+  flex: 1;
+  display: flex;
+  justify-content: center;
 }
 
 .icons {
@@ -217,6 +252,31 @@ footer {
   animation-delay: 1.12s;
 }
 
+.home .site-footer {
+  position: absolute;
+  bottom: 30px;
+  left: 0;
+  right: 0;
+  margin-top: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  z-index: 2;
+}
+
+.home .footer-inner {
+  justify-content: center;
+  gap: 40px;
+}
+
+.home .footer-meta {
+  display: none;
+}
+
+.home .footer-icons {
+  flex: unset;
+}
+
 @media (max-width: 768px) {
   .hero {
     padding-top: 64px;
@@ -232,7 +292,7 @@ footer {
     max-width: calc(100vw - 48px);
   }
 
-  footer {
+  .home .site-footer {
     bottom: 20px;
   }
 
@@ -245,6 +305,21 @@ footer {
   .icons .icon-wrapper {
     width: clamp(40px, 12vw, 56px);
     height: clamp(40px, 12vw, 56px);
+  }
+}
+
+@media (max-width: 768px) {
+  .footer-inner {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .footer-meta {
+    justify-items: center;
+  }
+
+  .footer-icons {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared header and footer partials so every page loads the same navigation and footer content
- introduce a lightweight include loader script and update the home page logic to wait for shared content
- refresh footer styling for both the hero landing page and notion-style subpages

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e41c2ddac88327ae38ce8735a6261d