### PR TITLE
Ensure subpage footers stay anchored to the bottom

### DIFF
--- a/style.css
+++ b/style.css
@@ -338,6 +338,9 @@ body.notion {
   background-color: #191919;
   color: #e3e5e5;
   padding-top: 72px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Error page */
@@ -416,6 +419,11 @@ body.error-page {
   max-width: 920px;
   margin: 0 auto 96px;
   padding: 32px 32px;
+}
+
+body.notion .notion-container {
+  flex: 1 0 auto;
+  width: 100%;
 }
 
 .notion-page-title {


### PR DESCRIPTION
## Summary
- convert subpage body layout to a column flex container so short pages stretch to full height
- allow the Notion-style main content wrapper to flex and fill remaining space, keeping the shared footer pinned to the viewport bottom

## Testing
- Manual inspection of http://127.0.0.1:8000/contact/


------
https://chatgpt.com/codex/tasks/task_e_68e41f64fe208327bec525f663728629