### PR TITLE
Update site theme colors and add images directory

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,12 +1,12 @@
 :root {
-  --brand-primary: #0f4c81;
-  --brand-accent: #f5a623;
+  --brand-primary: #001489;
+  --brand-accent: #ffd400;
   --surface: #f7f9fc;
   --text-color: #1f2933;
-  --nav-bg: #102a43;
-  --nav-text: #d9e2ec;
-  --border-color: rgba(15, 76, 129, 0.1);
-  --link-hover: #fbd38d;
+  --nav-bg: #001060;
+  --nav-text: #f0f3ff;
+  --border-color: rgba(0, 20, 137, 0.12);
+  --link-hover: #ffe25a;
   font-size: 16px;
   color-scheme: light;
 }
@@ -33,7 +33,7 @@ header {
   background: var(--brand-primary);
   color: #ffffff;
   padding: 1.75rem 2.5rem 1.5rem;
-  box-shadow: 0 4px 16px rgba(15, 76, 129, 0.25);
+  box-shadow: 0 4px 16px rgba(0, 16, 96, 0.25);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -66,7 +66,7 @@ nav {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  border-right: 1px solid rgba(255, 255, 255, 0.08);
+  border-right: 1px solid rgba(255, 255, 255, 0.12);
 }
 
 nav h2 {
@@ -98,13 +98,13 @@ nav a {
 
 nav a:hover,
 nav a:focus {
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.18);
   color: #ffffff;
   transform: translateX(4px);
 }
 
 nav a.active {
-  background: rgba(245, 166, 35, 0.16);
+  background: rgba(255, 212, 0, 0.22);
   color: #ffffff;
   box-shadow: inset 2px 0 0 var(--brand-accent);
 }
@@ -118,7 +118,7 @@ main {
   background: #ffffff;
   border-radius: 1.25rem;
   padding: 2.5rem;
-  box-shadow: 0 18px 32px rgba(15, 76, 129, 0.08);
+  box-shadow: 0 18px 32px rgba(0, 16, 96, 0.12);
   border: 1px solid var(--border-color);
   max-width: 960px;
 }
@@ -155,7 +155,7 @@ main {
   margin-top: 2rem;
   padding: 1.5rem;
   border-left: 4px solid var(--brand-accent);
-  background: rgba(15, 76, 129, 0.05);
+  background: rgba(0, 20, 137, 0.08);
   border-radius: 0.75rem;
 }
 

--- a/assets/images/.gitkeep
+++ b/assets/images/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep images directory in version control.


### PR DESCRIPTION
## Summary
- align the global CSS variables with the new blue and yellow color palette
- adjust component shadows and interactions to match the refreshed theme
- add an images directory scaffolded with a placeholder file for future assets

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0207ad408327b68fa45f7fa47c1e)