### PR TITLE
Add detailed course pages and update cluster overviews

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -159,6 +159,177 @@ main {
   border-radius: 0.75rem;
 }
 
+.course-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.course-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 10px 24px rgba(0, 16, 96, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.course-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--brand-primary);
+}
+
+.course-card h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.course-card h3 a:hover,
+.course-card h3 a:focus {
+  text-decoration: underline;
+}
+
+.course-card p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.course-card ul {
+  margin: 0;
+  padding-left: 1rem;
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.course-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.course-meta dl {
+  margin: 0;
+  background: rgba(0, 20, 137, 0.05);
+  border: 1px solid var(--border-color);
+  border-radius: 0.9rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.course-meta dt {
+  font-weight: 700;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--brand-primary);
+}
+
+.course-meta dt:first-of-type {
+  margin-top: 0;
+}
+
+.course-meta dd {
+  margin: 0.35rem 0 0;
+  font-size: 1rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--brand-primary);
+  margin-bottom: 1.5rem;
+}
+
+.back-link::before {
+  content: "←";
+  font-size: 1.1rem;
+}
+
+.photo-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.photo-gallery figure {
+  margin: 0;
+  background: #f3f4f6;
+  border: 1px dashed rgba(0, 20, 137, 0.3);
+  border-radius: 0.85rem;
+  padding: 1.25rem;
+  text-align: center;
+}
+
+.photo-placeholder {
+  font-weight: 600;
+  color: rgba(0, 20, 137, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+}
+
+.photo-gallery figcaption {
+  margin-top: 0.85rem;
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.faq {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.faq details {
+  border: 1px solid var(--border-color);
+  border-radius: 0.85rem;
+  padding: 1rem 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgba(0, 16, 96, 0.06);
+}
+
+.faq summary {
+  font-weight: 700;
+  cursor: pointer;
+  color: var(--brand-primary);
+}
+
+.faq p {
+  margin: 0.75rem 0 0;
+  line-height: 1.6;
+}
+
+.course-description {
+  margin-top: 2rem;
+}
+
+.course-description p {
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 960px) {
+  .course-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .course-meta {
+    grid-template-columns: 1fr;
+  }
+
+  .photo-gallery {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 960px) {
   body {
     grid-template-rows: auto auto 1fr;

--- a/computer-science-ap-computer-science-a.html
+++ b/computer-science-ap-computer-science-a.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AP Computer Science A | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>AP Computer Science A</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>AP Computer Science A</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>AP Computer Science Principles or prior programming experience.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>3 trimesters</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>AP Computer Science A is equivalent to a first-semester college programming course. Students develop software in Java while mastering object-oriented design, data structures, and algorithm analysis aligned to the AP exam.</p>
+          <p>Labs reinforce core concepts such as arrays, recursion, inheritance, and polymorphism. Students also explore debugging, unit testing, and collaborative version control practices used by professional developers.</p>
+          <p>Successful participants are prepared to pursue advanced computer science studies and internships requiring strong coding fundamentals.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students pair programming through AP CSA practice problems.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Whiteboard session analyzing algorithm efficiency.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>AP exam review highlighting free-response strategies.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Is Java the only language we use?</summary>
+            <p>Yes. Java is the primary language tested on the AP CSA exam and is used throughout the course.</p>
+          </details>
+          <details>
+            <summary>How fast-paced is the class?</summary>
+            <p>The course follows a college-level timeline. Consistent practice and attendance at help sessions support student success.</p>
+          </details>
+          <details>
+            <summary>Will we learn about software engineering tools?</summary>
+            <p>Students use IDEs, Git, and automated testing frameworks to mirror real-world development workflows.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science-ap-computer-science-principles.html
+++ b/computer-science-ap-computer-science-principles.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>AP Computer Science Principles | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>AP Computer Science Principles</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>AP Computer Science Principles</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Successful completion of Algebra I.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>3 trimesters</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>AP Computer Science Principles offers a broad introduction to computing. Students investigate how computing impacts society, analyze data, and develop programs that solve real problems while preparing for the AP Performance Tasks and exam.</p>
+          <p>Coursework includes creative coding challenges, data visualization projects, and discussions about cybersecurity and the digital divide. Students build digital portfolios documenting their artifacts and reflections.</p>
+          <p>Successful completion can earn college credit and provides a strong foundation for AP Computer Science A or advanced programming electives.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students collaborating on the Create Performance Task.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Data visualization projects displayed during class presentations.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>AP review session focused on practice multiple-choice questions.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Is this class only for future programmers?</summary>
+            <p>No. The course welcomes students interested in design, communication, and problem-solving across disciplines.</p>
+          </details>
+          <details>
+            <summary>How much homework should I expect?</summary>
+            <p>Expect regular reading, coding practice, and portfolio updates to stay on pace for the AP assessment.</p>
+          </details>
+          <details>
+            <summary>Do we have to take the AP exam?</summary>
+            <p>Students are strongly encouraged to take the exam to maximize college credit opportunities, but it is not mandatory.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science-networking-and-cybersecurity.html
+++ b/computer-science-networking-and-cybersecurity.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Networking &amp; Cybersecurity | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>Networking &amp; Cybersecurity</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Networking &amp; Cybersecurity</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Introductory computer science or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Networking &amp; Cybersecurity introduces students to the infrastructure that powers the internet and the strategies used to protect digital assets. Learners configure routers and switches, analyze network traffic, and explore defensive security practices.</p>
+          <p>Hands-on labs cover IP addressing, wireless networking, and vulnerability assessments using ethical hacking tools. Students practice documenting findings and recommending mitigation steps aligned with industry frameworks.</p>
+          <p>The class supports students pursuing industry certifications and sparks interest in careers such as network engineering, cybersecurity analysis, and IT support.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students configuring routers in the networking lab.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Packet analysis exercise using cybersecurity tools.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Guest speaker discussing careers in network defense.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do we need our own equipment?</summary>
+            <p>All networking gear and cybersecurity tools are provided. Students may bring laptops for note-taking and research.</p>
+          </details>
+          <details>
+            <summary>Will we prepare for industry certifications?</summary>
+            <p>Course content aligns with entry-level certifications such as CompTIA ITF+ and Network+ to help students continue their studies.</p>
+          </details>
+          <details>
+            <summary>Is ethical hacking included?</summary>
+            <p>Yes. Students learn ethical hacking concepts with an emphasis on responsible behavior and legal considerations.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science-video-game-design-i.html
+++ b/computer-science-video-game-design-i.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Video Game Design I | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>Video Game Design I</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Video Game Design I</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Video Game Design I introduces students to the fundamentals of interactive storytelling, game mechanics, and level design. Learners explore the design process from concept art to playable prototypes using beginner-friendly engines.</p>
+          <p>Students collaborate in teams to create 2D games, practice playtesting, and iterate on feedback. Topics include character design, user interface principles, and introductory programming concepts.</p>
+          <p>The course builds creative problem-solving skills and sets the stage for more advanced development experiences in Video Game Design II.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students sketching storyboards for game concepts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Pair programming session refining gameplay logic.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Playtesting feedback posted on the classroom board.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need to know how to code?</summary>
+            <p>No coding experience is required. The course uses visual scripting and step-by-step tutorials to build programming confidence.</p>
+          </details>
+          <details>
+            <summary>What software will we use?</summary>
+            <p>Students experiment with engines such as Construct, Unity, or GameMaker depending on project goals.</p>
+          </details>
+          <details>
+            <summary>Can I work on my own game idea?</summary>
+            <p>Yes. Individual and team projects are encouraged, with checkpoints to ensure scope remains manageable.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science-video-game-design-ii.html
+++ b/computer-science-video-game-design-ii.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Video Game Design II | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>Video Game Design II</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Video Game Design II</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Video Game Design I or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Video Game Design II challenges students to build polished games that incorporate advanced mechanics, animation, and audio design. Learners apply agile development practices and version control as they collaborate on multi-level experiences.</p>
+          <p>Students deepen programming skills with scripting languages, physics engines, and artificial intelligence behaviors. Emphasis is placed on user testing, accessibility, and publishing workflows.</p>
+          <p>The class culminates with a public showcase where teams pitch their games to peers, community members, and industry professionals.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Team sprint planning session using kanban boards.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Student demonstrating character animation techniques.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Showcase audience playing completed student games.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>What engines are supported?</summary>
+            <p>Unity and Unreal Engine are the primary platforms, though teams may propose alternatives that meet project requirements.</p>
+          </details>
+          <details>
+            <summary>Will we cover sound design?</summary>
+            <p>Yes. Students capture and edit audio effects, compose simple soundtracks, and integrate audio middleware.</p>
+          </details>
+          <details>
+            <summary>How is the course graded?</summary>
+            <p>Assessment focuses on sprint deliverables, teamwork reflections, and the final playable build.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science-web-page-design.html
+++ b/computer-science-web-page-design.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Web Page Design | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a class="active" href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="computer-science.html">Back to Computer Science</a>
+      <article class="content-card course-detail">
+        <h2>Web Page Design</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Web Page Design</dd>
+            <dt>Teachers</dt>
+            <dd>Computer Science &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Web Page Design teaches students how to plan, design, and build accessible websites using HTML, CSS, and introductory JavaScript. Learners practice user-centered design by creating responsive layouts that work on multiple devices.</p>
+          <p>Students explore branding, typography, and visual hierarchy while using wireframing tools to organize content. Projects include personal portfolios, community awareness sites, and client-based collaborations.</p>
+          <p>By the end of the course, each student launches a polished website hosted online and documents their process in a design case study.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students reviewing responsive layouts on tablets and laptops.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Wireframe sketches pinned on the critique wall.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Final websites presented during the digital showcase.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do we need prior design experience?</summary>
+            <p>No. The course introduces design fundamentals and provides templates to support beginners.</p>
+          </details>
+          <details>
+            <summary>Will we learn coding?</summary>
+            <p>Yes. Students write semantic HTML, craft CSS layouts, and use introductory JavaScript to add interactivity.</p>
+          </details>
+          <details>
+            <summary>Can we build sites for real clients?</summary>
+            <p>Students may partner with clubs or community organizations to develop live websites with instructor approval.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/computer-science.html
+++ b/computer-science.html
@@ -38,6 +38,56 @@
           <h3>Student Opportunities</h3>
           <p>Learners join coding clubs, participate in hackathons, and collaborate with engineering teams on embedded systems. Internship partnerships provide exposure to software careers and agile workflows.</p>
         </div>
+        <section class="course-grid" aria-label="Computer science courses">
+          <article class="course-card">
+            <h3><a href="computer-science-video-game-design-i.html">Video Game Design I</a></h3>
+            <p>Learn game design principles, storytelling, and introductory programming to build playable 2D experiences.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="computer-science-video-game-design-ii.html">Video Game Design II</a></h3>
+            <p>Expand game projects with advanced mechanics, collaborative sprints, and user experience playtesting.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="computer-science-ap-computer-science-principles.html">AP Computer Science Principles</a></h3>
+            <p>Investigate computing innovations, data, and creative coding while preparing for the AP Performance Tasks and exam.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 3 trimesters</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="computer-science-ap-computer-science-a.html">AP Computer Science A</a></h3>
+            <p>Master Java programming, object-oriented design, and algorithm analysis in alignment with AP CSA exam topics.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 3 trimesters</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="computer-science-web-page-design.html">Web Page Design</a></h3>
+            <p>Build responsive websites using HTML, CSS, and JavaScript with a focus on accessibility and user-centered design.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="computer-science-networking-and-cybersecurity.html">Networking &amp; Cybersecurity</a></h3>
+            <p>Configure small networks, troubleshoot connectivity, and practice defensive strategies against digital threats.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>

--- a/construction-basic-home-repair.html
+++ b/construction-basic-home-repair.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Basic Home Repair | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a class="active" href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="construction.html">Back to Construction</a>
+      <article class="content-card course-detail">
+        <h2>Basic Home Repair</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Basic Home Repair</dd>
+            <dt>Teachers</dt>
+            <dd>Construction &amp; Trades Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Basic Home Repair equips students with practical skills to maintain and improve residential spaces. Learners practice drywall patching, plumbing repairs, electrical troubleshooting, and preventative maintenance routines.</p>
+          <p>Projects are built around real-life scenarios, giving students confidence to diagnose issues, source materials, and complete repairs safely. Emphasis is placed on tool selection, safety, and clear communication with homeowners.</p>
+          <p>The course is ideal for students interested in DIY projects, future homeownership, or introductory exposure to trades careers.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students repairing a section of drywall in the lab.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Hands-on plumbing demonstration using copper and PEX fittings.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Tool identification activity focused on safe operation.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do we work on real houses?</summary>
+            <p>Most work occurs in lab modules that simulate residential systems. Select projects may involve on-campus maintenance opportunities.</p>
+          </details>
+          <details>
+            <summary>What safety gear is required?</summary>
+            <p>Safety glasses and closed-toe shoes are required daily. Gloves, hearing protection, and masks are provided as needed.</p>
+          </details>
+          <details>
+            <summary>Will this course help with future trades programs?</summary>
+            <p>Yes. Students gain foundational skills and confidence that transfer to advanced construction courses and apprenticeship pathways.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/construction-small-structures.html
+++ b/construction-small-structures.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Small Structures | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a class="active" href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="construction.html">Back to Construction</a>
+      <article class="content-card course-detail">
+        <h2>Small Structures</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Small Structures</dd>
+            <dt>Teachers</dt>
+            <dd>Construction &amp; Trades Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Basic Home Repair or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Small Structures guides students through the complete construction of sheds, playhouses, and specialty outdoor buildings. Learners interpret blueprints, estimate materials, and coordinate crew roles from foundation to finish.</p>
+          <p>Projects incorporate framing, roofing, siding, electrical rough-in, and finishing details. Students practice jobsite communication, scheduling, and inspection procedures used by professional contractors.</p>
+          <p>Many builds serve community partners, giving students real-world experience and a portfolio of completed work.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Framing walls for a student-designed shed.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Installing shingles during roofing practice.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Completed structure delivered to a local partner.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Where are projects built?</summary>
+            <p>Most structures are built on campus and transported to their final location. Some projects may be constructed on-site with partner organizations.</p>
+          </details>
+          <details>
+            <summary>What tools will we use?</summary>
+            <p>Students operate miter saws, nailers, ladders, and layout tools under close supervision after safety certification.</p>
+          </details>
+          <details>
+            <summary>Can I use this experience for a resume?</summary>
+            <p>Yes. Students document their role, take progress photos, and receive instructor references for internships or apprenticeships.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/construction.html
+++ b/construction.html
@@ -38,6 +38,24 @@
           <h3>Community Partnerships</h3>
           <p>Students partner with local trades to complete service projects, tour active jobsites, and prepare for apprenticeships. Advisory committees keep curriculum aligned with workforce needs.</p>
         </div>
+        <section class="course-grid" aria-label="Construction courses">
+          <article class="course-card">
+            <h3><a href="construction-basic-home-repair.html">Basic Home Repair</a></h3>
+            <p>Practice essential maintenance tasks including drywall patching, fixture replacement, and preventative home care.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="construction-small-structures.html">Small Structures</a></h3>
+            <p>Design and build sheds, playhouses, and other small-scale structures using framing, roofing, and finishing skills.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>

--- a/engineering-engineering-i.html
+++ b/engineering-engineering-i.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering I | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a class="active" href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="engineering.html">Back to Engineering</a>
+      <article class="content-card course-detail">
+        <h2>Engineering I</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Engineering I</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Algebra I (concurrent enrollment allowed).</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Engineering I introduces the engineering design process through rapid ideation, prototyping, and iterative testing. Students learn to sketch concepts, develop 3D models, and evaluate solutions using data-driven decision making.</p>
+          <p>Hands-on challenges such as bridge design, electronic toys, and assistive devices encourage collaboration across disciplines. Learners document progress using engineering notebooks and present findings to peers and community partners.</p>
+          <p>This course serves as the launching point for the engineering pathway and builds confidence with industry-standard communication and teamwork practices.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students prototyping solutions with cardboard and 3D printed parts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Design review featuring engineering notebook entries.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Testing bridge designs on the structural load frame.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need to be good at math?</summary>
+            <p>Engineering I reinforces math concepts through practical application. Instructors provide support so students can connect calculations with real-world outcomes.</p>
+          </details>
+          <details>
+            <summary>Is there a lot of group work?</summary>
+            <p>Collaboration is central to the course. Teams practice professional roles, conflict resolution, and shared documentation habits.</p>
+          </details>
+          <details>
+            <summary>What software will we use?</summary>
+            <p>Students explore CAD platforms such as SOLIDWORKS or Onshape, along with data logging and presentation tools.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/engineering-engineering-ii-applied-engineering.html
+++ b/engineering-engineering-ii-applied-engineering.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering II: Applied Engineering | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a class="active" href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="engineering.html">Back to Engineering</a>
+      <article class="content-card course-detail">
+        <h2>Engineering II: Applied Engineering</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Engineering II: Applied Engineering</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Engineering I or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Engineering II: Applied Engineering empowers students to tackle open-ended problems in areas such as renewable energy, biomedical devices, and smart systems. Learners conduct research, analyze constraints, and prototype solutions using interdisciplinary tools.</p>
+          <p>Students collaborate with mentors from industry or higher education, gaining experience with project management software, user interviews, and technical documentation. Emphasis is placed on systems thinking and ethical decision making.</p>
+          <p>The course culminates with a formal design review where teams present their findings and reflect on how their solutions impact users and communities.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Teams conducting usability tests on prototype devices.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Student presenting research findings to an industry mentor.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Iterative prototypes displayed during design review.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>How are projects selected?</summary>
+            <p>Students pitch project ideas, evaluate feasibility, and form teams around shared interests or community needs.</p>
+          </details>
+          <details>
+            <summary>Will we work with real clients?</summary>
+            <p>Yes. Applied Engineering frequently partners with nonprofits, school departments, or local businesses to ensure solutions are user-centered.</p>
+          </details>
+          <details>
+            <summary>What presentation skills are developed?</summary>
+            <p>Teams practice technical writing, poster design, and formal presentations to communicate engineering decisions clearly.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/engineering-engineering-ii-manufacturing.html
+++ b/engineering-engineering-ii-manufacturing.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Engineering II: Manufacturing | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a class="active" href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="engineering.html">Back to Engineering</a>
+      <article class="content-card course-detail">
+        <h2>Engineering II: Manufacturing</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Engineering II: Manufacturing</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Engineering I or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Engineering II: Manufacturing blends engineering design with production techniques used in modern factories. Students analyze material properties, create process plans, and deploy CNC equipment to deliver precise components.</p>
+          <p>Emphasis is placed on fixture design, tolerancing, and automation as learners integrate robotics or PLC concepts into their workflows. Teams document quality metrics and apply lean principles to optimize throughput.</p>
+          <p>Community-based projects provide authentic experience producing parts for robotics teams, school facilities, or local businesses.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students programming toolpaths for CNC milling operations.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Inspection station verifying tolerances on machined parts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Team collaborating on a production workflow map.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>How is this class different from Mass Production?</summary>
+            <p>Manufacturing emphasizes engineering analysis and automation, while Mass Production focuses on business operations and large-batch product delivery.</p>
+          </details>
+          <details>
+            <summary>Do we work with industry partners?</summary>
+            <p>Yes. Guest speakers and project briefs from local manufacturers expose students to real-world expectations.</p>
+          </details>
+          <details>
+            <summary>What software tools are used?</summary>
+            <p>Students leverage CAD/CAM software, statistical process control tools, and digital workflow platforms.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/engineering-robotics.html
+++ b/engineering-robotics.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Robotics | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a class="active" href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="engineering.html">Back to Engineering</a>
+      <article class="content-card course-detail">
+        <h2>Robotics</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Robotics</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Engineering I or concurrent enrollment in a technology course.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Robotics introduces students to mechanical design, electronics, and programming through competition-style challenges. Teams build mobile robots that navigate obstacles, manipulate game pieces, and respond to autonomous routines.</p>
+          <p>Students learn to apply sensors, microcontrollers, and CAD-driven fabrication while practicing iterative testing. Collaboration mirrors industry engineering teams with roles covering design, fabrication, coding, and strategy.</p>
+          <p>The course encourages participation in after-school robotics programs and supports students pursuing leadership roles on competition teams.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Robot chassis assembled on the build table.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Programming team tuning autonomous routines.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students competing at a regional robotics event.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need programming experience?</summary>
+            <p>No prior coding is required. The course introduces block-based and text-based programming tied directly to robot controls.</p>
+          </details>
+          <details>
+            <summary>What competitions are supported?</summary>
+            <p>Students may participate in FIRST Robotics Competition or VEX programs depending on the season and team availability.</p>
+          </details>
+          <details>
+            <summary>Is there a fee to join?</summary>
+            <p>Course materials are provided. Optional travel for competitions may include fundraising or activity fees coordinated with the robotics team.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/engineering-solidworks-certified.html
+++ b/engineering-solidworks-certified.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SOLIDWORKS Certified | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a class="active" href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="engineering.html">Back to Engineering</a>
+      <article class="content-card course-detail">
+        <h2>SOLIDWORKS Certified</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>SOLIDWORKS Certified</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Engineering I and concurrent or prior CAD experience.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>SOLIDWORKS Certified prepares students for the Certified SOLIDWORKS Associate (CSWA) exam. Learners master advanced part modeling, assemblies, drawing creation, and design intent strategies that align with industry standards.</p>
+          <p>Students work through certification-aligned practice exams, receiving individualized coaching on efficiency, modeling best practices, and documentation requirements. Real-world design briefs reinforce the application of CAD skills to engineering challenges.</p>
+          <p>The course culminates with students attempting the CSWA exam and compiling a digital portfolio that highlights professional design work.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students collaborating on multi-body part modeling strategies.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Assembly mates and motion studies reviewed on screen.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Certification celebration highlighting student achievements.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Is the CSWA exam fee covered?</summary>
+            <p>The program provides exam vouchers for students who meet readiness benchmarks established by the instructor.</p>
+          </details>
+          <details>
+            <summary>Do I need my own computer?</summary>
+            <p>Workstations are available in the lab. Students with capable laptops may install SOLIDWORKS through the school’s licensing program.</p>
+          </details>
+          <details>
+            <summary>What happens if I already have CAD experience?</summary>
+            <p>Students may test out of introductory modules and focus on advanced practice sets or industry projects.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/engineering.html
+++ b/engineering.html
@@ -38,6 +38,48 @@
           <h3>Beyond the Classroom</h3>
           <p>Students compete on robotics teams, collaborate with math and science departments, and attend STEM career nights. Advisory boards keep curriculum aligned with industry expectations.</p>
         </div>
+        <section class="course-grid" aria-label="Engineering courses">
+          <article class="course-card">
+            <h3><a href="engineering-engineering-i.html">Engineering I</a></h3>
+            <p>Explore the engineering design process through rapid prototyping, CAD modeling, and collaborative design challenges.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="engineering-engineering-ii-manufacturing.html">Engineering II: Manufacturing</a></h3>
+            <p>Combine automation concepts with machining and fabrication workflows to produce reliable, repeatable parts.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="engineering-engineering-ii-applied-engineering.html">Engineering II: Applied Engineering</a></h3>
+            <p>Apply mechanical, electrical, and software concepts to solve open-ended problems in multidisciplinary project teams.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="engineering-solidworks-certified.html">SOLIDWORKS Certified</a></h3>
+            <p>Prepare for the CSWA exam with advanced parametric modeling, assemblies, and drawing standards using SOLIDWORKS.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="engineering-robotics.html">Robotics</a></h3>
+            <p>Design, build, and program competition-ready robots while practicing systems integration and iterative testing.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>

--- a/metals-foundations-of-metals.html
+++ b/metals-foundations-of-metals.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Foundations of Metals | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a class="active" href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="metals.html">Back to Metals</a>
+      <article class="content-card course-detail">
+        <h2>Foundations of Metals</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Foundations of Metals</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None; perfect starting point for the metals pathway.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Foundations of Metals introduces students to the vocabulary, processes, and safety expectations that drive success in the fabrication lab. Learners progress from hands-on tool demonstrations to producing functional artifacts that showcase measurement accuracy and finishing techniques.</p>
+          <p>Projects emphasize the engineering design cycle, encouraging students to sketch concepts, plan workflows, and document results. Along the way, learners practice professional shop etiquette and develop confidence navigating equipment ranging from layout tools to basic welding processes.</p>
+          <p>By the end of the term, students have assembled a portfolio of small products and reflection notes that prepare them for the rigors of advanced metals coursework.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students practicing layout and measurement fundamentals.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Introductory welding beads completed during safety certification.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished entry-level projects on display in the metals lab.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need previous shop experience?</summary>
+            <p>No prior shop experience is required. The course begins with safety procedures and guided practice on every tool before independent work begins.</p>
+          </details>
+          <details>
+            <summary>What safety gear is provided?</summary>
+            <p>The program supplies welding jackets, gloves, helmets, and safety glasses. Students are encouraged to bring closed-toe shoes and long pants daily.</p>
+          </details>
+          <details>
+            <summary>How will this class prepare me for advanced metals courses?</summary>
+            <p>By mastering measurement, layout, and shop protocols, you will be ready to take General Metals, Welding, or other advanced electives with confidence.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/metals-general-metals.html
+++ b/metals-general-metals.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>General Metals | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a class="active" href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="metals.html">Back to Metals</a>
+      <article class="content-card course-detail">
+        <h2>General Metals</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>General Metals</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Foundations of Metals or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>General Metals builds on foundational skills by introducing more complex fabrication processes and tighter tolerances. Students rotate through machining, forming, and welding stations while managing quality checkpoints for each project.</p>
+          <p>Team-based challenges simulate industry roles such as fabricator, inspector, and project manager, giving learners insight into manufacturing workflows. Emphasis is placed on reading prints, selecting the right tooling, and documenting adjustments.</p>
+          <p>Students finish the course with a portfolio of intermediate projects that highlight craftsmanship and problem-solving, preparing them for specialty courses such as Welding or Mass Production.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students referencing blueprints before machining parts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Partner teams performing quality checks on assemblies.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Completed metal projects showcased during open house.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>How is General Metals different from Foundations of Metals?</summary>
+            <p>General Metals moves faster, involves more independent work, and introduces additional machines that require proficiency with measurement and layout.</p>
+          </details>
+          <details>
+            <summary>Will I earn any certifications?</summary>
+            <p>While certifications are not awarded in this course, successful students are well prepared to pursue welding or machining credentials offered in advanced electives.</p>
+          </details>
+          <details>
+            <summary>Can I repeat the class for credit?</summary>
+            <p>Students may repeat General Metals with instructor approval if they are pursuing an advanced project or leadership role in the lab.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/metals-mass-production.html
+++ b/metals-mass-production.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Mass Production | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a class="active" href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="metals.html">Back to Metals</a>
+      <article class="content-card course-detail">
+        <h2>Mass Production</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Mass Production</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>General Metals and instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Mass Production simulates a small-scale manufacturing environment where students produce a limited run of market-ready products. Learners analyze customer requirements, engineer fixtures, and document standardized work instructions.</p>
+          <p>Teams explore lean manufacturing strategies such as 5S, kanban, and continuous improvement to streamline production. Data collection and reflection guide adjustments that improve throughput and quality.</p>
+          <p>Profits from product sales support program enhancements or community causes, giving students real-world experience managing budgets and client expectations.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students assembling components on a mass production line.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Quality control station reviewing finished goods.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Packaging and distribution setup for student-designed products.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>What types of products do students make?</summary>
+            <p>Each cohort researches market needs and votes on a product concept. Past projects have included metal art, household tools, and community service items.</p>
+          </details>
+          <details>
+            <summary>Is business content included?</summary>
+            <p>Yes. Students create cost projections, marketing materials, and sales plans in collaboration with business classes when possible.</p>
+          </details>
+          <details>
+            <summary>How are roles assigned within teams?</summary>
+            <p>Teams rotate through roles such as production lead, quality manager, and logistics coordinator so every student experiences multiple perspectives.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/metals-sheet-metal.html
+++ b/metals-sheet-metal.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sheet Metal | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a class="active" href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="metals.html">Back to Metals</a>
+      <article class="content-card course-detail">
+        <h2>Sheet Metal</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Sheet Metal</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>General Metals or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Sheet Metal focuses on layout, cutting, and forming light-gauge metals for both functional and decorative applications. Students learn pattern development, bend allowances, and fastening methods used in HVAC, aerospace, and product design.</p>
+          <p>Hands-on labs include shearing, punching, notching, and brake forming to create precise seams and joints. Learners integrate CAD files with CNC plasma cutters to accelerate production while maintaining tight tolerances.</p>
+          <p>Final projects encourage creativity as students design custom ductwork, enclosures, or sculptural pieces that highlight material efficiency and craftsmanship.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students programming the CNC plasma cutter for sheet layouts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Forming complex bends on the box and pan brake.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished sheet metal assemblies ready for installation.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>How much math is involved?</summary>
+            <p>Students apply measurement conversions, geometry, and trigonometry when developing patterns. Instruction includes step-by-step support to build confidence with calculations.</p>
+          </details>
+          <details>
+            <summary>Can projects support other classes?</summary>
+            <p>Yes. Sheet Metal students frequently collaborate with Engineering and Construction courses to fabricate custom components for shared projects.</p>
+          </details>
+          <details>
+            <summary>Will I work with CAD software?</summary>
+            <p>Students use CAD to model flat patterns and export cut files for CNC equipment, reinforcing digital fabrication skills.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/metals-welding.html
+++ b/metals-welding.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Welding | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a class="active" href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="metals.html">Back to Metals</a>
+      <article class="content-card course-detail">
+        <h2>Welding</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Welding</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>General Metals or equivalent fabrication experience.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>The Welding course immerses students in SMAW, GMAW, and GTAW processes using professional-grade equipment. Learners master joint preparation, electrode selection, and welding positions while following American Welding Society guidelines.</p>
+          <p>Daily lab time focuses on building consistent technique through weld coupons and destructive testing. Students document progress in a weld log and receive targeted feedback aligned to industry certification standards.</p>
+          <p>Capstone projects challenge students to fabricate structural assemblies, repair damaged components, or create artistic pieces that demonstrate craftsmanship and safety awareness.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Welding booths set up for MIG and TIG practice.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students inspecting weld beads during quality checks.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Final structural project prepared for evaluation.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Is certification testing available?</summary>
+            <p>Students can complete practice tests toward AWS entry-level certifications. Formal testing opportunities are arranged based on interest and readiness.</p>
+          </details>
+          <details>
+            <summary>What personal protective equipment is required?</summary>
+            <p>Leather boots, welding gloves, and safety glasses are required. Helmets and jackets are available for student use, though many choose to purchase their own gear.</p>
+          </details>
+          <details>
+            <summary>Can I work on personal or community projects?</summary>
+            <p>Yes, after demonstrating proficiency, students may propose personal or service projects that align with course objectives and safety protocols.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/metals.html
+++ b/metals.html
@@ -36,6 +36,48 @@
         </ul>
         <h3>Capstone Experiences</h3>
         <p>Advanced students take on custom fabrication projects for community partners, compete in SkillsUSA manufacturing events, and learn to maintain shop equipment. Portfolio-ready documentation supports apprenticeships and technical college admissions.</p>
+        <section class="course-grid" aria-label="Metals courses">
+          <article class="course-card">
+            <h3><a href="metals-foundations-of-metals.html">Foundations of Metals</a></h3>
+            <p>Build confidence with hand tools, measurement, and introductory fabrication projects while developing strong safety habits.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="metals-general-metals.html">General Metals</a></h3>
+            <p>Advance layout, cutting, and assembly skills through multi-step projects that emphasize precision and craftsmanship.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="metals-welding.html">Welding</a></h3>
+            <p>Focus on MIG, TIG, and stick welding techniques while preparing for entry-level certifications and industry expectations.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="metals-sheet-metal.html">Sheet Metal</a></h3>
+            <p>Create custom enclosures and ducting components using shearing, forming, and fastening processes used in industry.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="metals-mass-production.html">Mass Production</a></h3>
+            <p>Collaborate on small-batch product runs to learn workflow planning, quality control, and efficient fabrication methods.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>

--- a/other-architecture.html
+++ b/other-architecture.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Architecture | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Architecture</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Architecture</dd>
+            <dt>Teachers</dt>
+            <dd>Architecture &amp; Design Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Geometry (completed or in progress).</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Architecture invites students to explore the built environment through design thinking. Learners analyze precedent projects, produce architectural drawings, and create 3D models using both physical and digital tools.</p>
+          <p>Topics include site analysis, spatial planning, building codes, and sustainability strategies. Students use industry-standard software to draft floor plans, elevations, and renderings.</p>
+          <p>Final projects present comprehensive design proposals for residential or community spaces, complete with client narratives and material boards.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students developing concept sketches during design charrettes.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>3D printed architectural models created in the makerspace.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Presentation boards displayed for critique.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need drawing skills?</summary>
+            <p>No formal art background is required. The course teaches sketching techniques and digital workflows from the ground up.</p>
+          </details>
+          <details>
+            <summary>What software will we learn?</summary>
+            <p>Students explore tools such as SketchUp, Revit, or AutoCAD, along with rendering platforms like Lumion.</p>
+          </details>
+          <details>
+            <summary>Will we visit real buildings?</summary>
+            <p>Yes. Local site visits and virtual tours expose students to diverse architectural styles and careers.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-aviation-i.html
+++ b/other-aviation-i.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Aviation I | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Aviation I</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Aviation I</dd>
+            <dt>Teachers</dt>
+            <dd>Aviation &amp; STEM Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Algebra I and instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Aviation I introduces students to flight theory, aerodynamics, and aviation history. Learners study aircraft systems, meteorology, navigation, and radio communication while applying concepts in desktop flight simulators.</p>
+          <p>Guest speakers from the aviation industry provide insight into pilot, maintenance, and air traffic control careers. Students also explore drone technology and aviation safety protocols.</p>
+          <p>The class prepares students for advanced study in Aviation II and encourages pursuit of discovery flights or private pilot ground school.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students practicing takeoffs and landings in flight simulators.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Hands-on lesson exploring aircraft control surfaces.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Field trip to a local airport for an aircraft walkaround.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Is there a lab fee?</summary>
+            <p>A modest fee may apply for simulator maintenance and field trip transportation. Financial assistance is available.</p>
+          </details>
+          <details>
+            <summary>Do students fly real aircraft?</summary>
+            <p>Discovery flights may be offered through community partners outside of class time. Flight simulators are used during the course.</p>
+          </details>
+          <details>
+            <summary>Can this lead to pilot certification?</summary>
+            <p>Aviation I provides foundational knowledge that supports future ground school and flight training toward certification.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-aviation-ii.html
+++ b/other-aviation-ii.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Aviation II | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Aviation II</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Aviation II</dd>
+            <dt>Teachers</dt>
+            <dd>Aviation &amp; STEM Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 11-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Aviation I or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Aviation II builds on foundational knowledge with advanced navigation, flight planning, and weather analysis. Students complete cross-country flight simulations, interpret aviation charts, and study emergency procedures.</p>
+          <p>Guest pilots mentor students through scenario-based training and introduce career pathways in commercial aviation, unmanned systems, and aerospace engineering. Learners also explore aviation management and airport operations.</p>
+          <p>The course prepares students for private pilot ground school or aviation college programs, emphasizing leadership and decision-making.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students planning a cross-country route using sectional charts.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Advanced simulator session practicing instrument approaches.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Industry mentor discussing aviation career pathways.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do we earn any certifications?</summary>
+            <p>The course prepares students for FAA written exam content. Formal certification requires additional external training.</p>
+          </details>
+          <details>
+            <summary>Is aviation math involved?</summary>
+            <p>Yes. Students apply trigonometry and physics to calculate headings, fuel burn, and weight and balance considerations.</p>
+          </details>
+          <details>
+            <summary>Can this class count toward science credit?</summary>
+            <p>Credit alignment varies by year. Consult a counselor to confirm how Aviation II fits in your graduation plan.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-classes.html
+++ b/other-classes.html
@@ -38,6 +38,64 @@
           <h3>Plan Your Journey</h3>
           <p>Students meet with counselors to map multi-year plans that stack skills, earn industry certifications, and qualify for articulated college credit. Clubs and summer workshops keep momentum going all year.</p>
         </div>
+        <section class="course-grid" aria-label="Additional courses">
+          <article class="course-card">
+            <h3><a href="other-electronics.html">Electronics</a></h3>
+            <p>Investigate circuits, components, and testing equipment while building functional prototypes and troubleshooting systems.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-fishing.html">Fishing</a></h3>
+            <p>Study aquatic ecosystems, tackle selection, and conservation practices alongside hands-on angling experiences.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-small-engines.html">Small Engines</a></h3>
+            <p>Disassemble and rebuild engines to understand combustion principles, diagnostics, and preventative maintenance.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-aviation-i.html">Aviation I</a></h3>
+            <p>Discover aviation history, flight theory, and simulator practice while exploring careers in aerospace.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-aviation-ii.html">Aviation II</a></h3>
+            <p>Dive deeper into navigation, weather analysis, and flight planning while advancing simulator proficiency.</p>
+            <ul>
+              <li>Grades: 11-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-architecture.html">Architecture</a></h3>
+            <p>Blend artistic vision with technical drawing as you design structures using both hand sketching and CAD tools.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="other-robotics-open-shop.html">Robotics Open Shop</a></h3>
+            <p>Collaborate with peers to iterate on competition robots, practice advanced fabrication, and mentor younger teams.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>

--- a/other-electronics.html
+++ b/other-electronics.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Electronics | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Electronics</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Electronics</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Algebra I or concurrent enrollment.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Electronics introduces students to the fundamentals of electricity, circuit design, and soldering. Learners analyze schematics, build breadboard prototypes, and troubleshoot circuits using multimeters and oscilloscopes.</p>
+          <p>Topics include Ohm’s Law, series and parallel circuits, semiconductor devices, and microcontroller basics. Students complete hands-on projects such as audio amplifiers, smart lighting, or wearable electronics.</p>
+          <p>The course provides a strong foundation for engineering, robotics, and computer science pathways that rely on embedded systems.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students soldering components onto custom circuit boards.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Breadboard prototypes connected to diagnostic equipment.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Completed electronics projects displayed during demo day.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need math skills?</summary>
+            <p>Yes. Basic algebra is used to calculate voltage, current, and resistance. Lessons include guided practice to build confidence.</p>
+          </details>
+          <details>
+            <summary>Can I take Electronics with Robotics?</summary>
+            <p>Absolutely. Electronics pairs well with Robotics and Engineering courses, enhancing your understanding of control systems.</p>
+          </details>
+          <details>
+            <summary>Will we use microcontrollers?</summary>
+            <p>Students experiment with microcontroller platforms to build interactive projects and learn introductory programming.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-fishing.html
+++ b/other-fishing.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fishing | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Fishing</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Fishing</dd>
+            <dt>Teachers</dt>
+            <dd>Outdoor Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Ability to swim and parental permission for off-site trips.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Fishing combines outdoor recreation with environmental stewardship. Students learn fish identification, aquatic ecology, and responsible angling techniques while practicing casting, knot tying, and tackle selection.</p>
+          <p>Field experiences include shore fishing, ice fishing (season permitting), and visits from conservation officers. Learners analyze water quality data, discuss habitat conservation, and plan sustainable outings.</p>
+          <p>The course emphasizes lifelong recreation skills and fosters appreciation for Minnesota’s natural resources.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students practicing casting techniques on campus.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Ice fishing excursion with safety briefing.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Classroom session analyzing lake maps and habitat zones.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Do I need my own equipment?</summary>
+            <p>Basic rods, reels, and tackle are provided. Students may bring personal gear if labeled.</p>
+          </details>
+          <details>
+            <summary>Are fishing licenses required?</summary>
+            <p>Students age 16 and older must have a valid Minnesota fishing license. Guidance is provided during enrollment.</p>
+          </details>
+          <details>
+            <summary>What happens in bad weather?</summary>
+            <p>Indoor sessions focus on skills such as lure building, fish biology, and trip planning until conditions improve.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-robotics-open-shop.html
+++ b/other-robotics-open-shop.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Robotics Open Shop | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Robotics Open Shop</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Robotics Open Shop</dd>
+            <dt>Teachers</dt>
+            <dd>Robotics &amp; Engineering Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Concurrent enrollment in a robotics or engineering course, or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester (repeatable)</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Robotics Open Shop offers structured lab time for students to advance robotics projects beyond the traditional classroom setting. Teams prototype mechanisms, refine programming, and document engineering notebooks in preparation for competition season.</p>
+          <p>Mentors provide targeted workshops on advanced fabrication, sensor integration, and strategic analysis. Students set weekly goals, manage budgets, and maintain equipment readiness.</p>
+          <p>The flexible format supports competition teams, outreach initiatives, and cross-curricular collaborations with engineering and computer science courses.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Evening build session assembling drivetrain components.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Programming station testing autonomous routines.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Team strategizing with mentors before a scrimmage.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>How is attendance tracked?</summary>
+            <p>Students log hours and progress milestones each session to demonstrate growth and maintain eligibility.</p>
+          </details>
+          <details>
+            <summary>Can new members join mid-term?</summary>
+            <p>Yes, with instructor approval. Orientation sessions help new members learn safety protocols and team expectations.</p>
+          </details>
+          <details>
+            <summary>Is transportation provided for events?</summary>
+            <p>Competition travel is coordinated through the robotics team. Fundraising helps offset costs when possible.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/other-small-engines.html
+++ b/other-small-engines.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Small Engines | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a class="active" href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="other-classes.html">Back to Other Classes</a>
+      <article class="content-card course-detail">
+        <h2>Small Engines</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Small Engines</dd>
+            <dt>Teachers</dt>
+            <dd>Automotive &amp; Power Equipment Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Small Engines provides hands-on experience diagnosing, disassembling, and rebuilding two- and four-stroke engines. Students learn about ignition systems, carburetion, lubrication, and routine maintenance for equipment such as lawn mowers and snow blowers.</p>
+          <p>Each student completes a full engine teardown and reassembly while documenting torque specs, clearances, and troubleshooting steps. Safety and environmental stewardship are emphasized through proper chemical handling and recycling practices.</p>
+          <p>The course lays the groundwork for advanced automotive technology classes or entry-level positions in power sports and maintenance shops.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students cataloging engine parts during disassembly.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Compression testing engines after reassembly.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished engines running on the test stand.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Can I bring my own engine?</summary>
+            <p>With instructor approval, students may work on personal or community engines that match course objectives.</p>
+          </details>
+          <details>
+            <summary>What safety gear is required?</summary>
+            <p>Safety glasses, gloves, and appropriate clothing are required. Additional PPE is provided for specific labs.</p>
+          </details>
+          <details>
+            <summary>Will we cover fuel system tuning?</summary>
+            <p>Yes. Students learn to adjust carburetors, set governor controls, and diagnose fuel delivery issues.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/woods-woods-i.html
+++ b/woods-woods-i.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Woods I | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a class="active" href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="woods.html">Back to Woods</a>
+      <article class="content-card course-detail">
+        <h2>Woods I</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Woods I</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 9-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>None.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Woods I introduces students to woodworking safety, measurement, and core joinery techniques. Learners operate saws, planers, sanders, and handheld tools with instructor guidance before applying their skills independently.</p>
+          <p>Projects emphasize accuracy and craftsmanship, ranging from cutting boards to small furniture items. Students reflect on progress in a design journal that documents measurements, material selection, and finishing choices.</p>
+          <p>The course builds a solid foundation for advanced woodworking experiences, empowering learners to confidently take on more complex builds in Woods II.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students setting up the table saw with safety guards in place.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Glue-up of a cutting board during clamp practice.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished introductory projects displayed for critique.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>What should I wear to class?</summary>
+            <p>Closed-toe shoes and clothing that can get dusty are required. Long hair must be tied back and jewelry removed before lab work.</p>
+          </details>
+          <details>
+            <summary>Do I need to purchase lumber?</summary>
+            <p>Standard project materials are supplied. Students may purchase specialty hardwoods if they choose to customize projects.</p>
+          </details>
+          <details>
+            <summary>How much homework should I expect?</summary>
+            <p>Most work is completed during class. Short reflections and project planning sketches may be assigned outside of lab time.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/woods-woods-ii-cabinetmaking.html
+++ b/woods-woods-ii-cabinetmaking.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Woods II: Cabinetmaking | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a class="active" href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="woods.html">Back to Woods</a>
+      <article class="content-card course-detail">
+        <h2>Woods II: Cabinetmaking</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Woods II: Cabinetmaking</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Successful completion of Woods I.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Woods II: Cabinetmaking deepens woodworking skills with a focus on case construction, drawer systems, and door fabrication. Students interpret architectural drawings, draft cut lists, and optimize material usage for large-scale projects.</p>
+          <p>Advanced tooling such as the panel saw, dovetail jig, and European hinge systems are introduced. Learners gain experience assembling carcasses, applying veneers, and installing hardware for professional-quality cabinetry.</p>
+          <p>Each student completes a custom cabinet or built-in solution designed to meet the needs of a client, classroom, or community partner.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Cabinet carcasses clamped for square alignment.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students installing concealed hinges on frameless doors.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished cabinetry projects ready for delivery.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Will I learn to use CNC equipment?</summary>
+            <p>Yes. Students incorporate CNC routing for precision parts and repeatable drilling patterns when appropriate.</p>
+          </details>
+          <details>
+            <summary>Can we work with real clients?</summary>
+            <p>Many projects support school or community needs. Students follow a client brief, submit design proposals, and present completed work.</p>
+          </details>
+          <details>
+            <summary>Is this course good preparation for carpentry careers?</summary>
+            <p>Cabinetmaking strengthens layout, joinery, and finishing skills that align with cabinet shops, finish carpentry, and interior design careers.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/woods-woods-ii-furniture-making.html
+++ b/woods-woods-ii-furniture-making.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Woods II: Furniture Making | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a class="active" href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="woods.html">Back to Woods</a>
+      <article class="content-card course-detail">
+        <h2>Woods II: Furniture Making</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Woods II: Furniture Making</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 10-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Successful completion of Woods I.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Woods II: Furniture Making challenges students to design and build heirloom-quality furniture using advanced joinery and finishing techniques. Learners study ergonomics, wood movement, and historical furniture styles to inform their designs.</p>
+          <p>Projects may include tables, chairs, or storage pieces crafted with mortise and tenon joints, bent laminations, or veneered panels. Students experiment with stains, dyes, and topcoats to achieve professional finishes.</p>
+          <p>Design critiques and client feedback sessions help students iterate on prototypes, resulting in refined pieces ready for exhibition or sale.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students refining mortise and tenon joinery on chair frames.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Steam-bending station used for curved furniture components.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Finished furniture pieces staged for the design showcase.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Can I design my own project?</summary>
+            <p>Absolutely. Students propose original designs, create detailed plans, and iterate with instructor feedback to ensure feasibility.</p>
+          </details>
+          <details>
+            <summary>Are upholstery skills covered?</summary>
+            <p>Basic upholstery techniques may be introduced for select projects. Students interested in advanced upholstery receive guidance on community resources.</p>
+          </details>
+          <details>
+            <summary>Will my project be displayed publicly?</summary>
+            <p>Furniture pieces are featured in the annual woods showcase and may be submitted to regional competitions.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/woods-woods-iii.html
+++ b/woods-woods-iii.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Woods III | STMA Technology &amp; Engineering Education</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <header>
+    <h1>STMA Technology &amp; Engineering Education</h1>
+    <p>Empowering students with hands-on experience, critical thinking, and innovation across the technology and engineering spectrum.</p>
+  </header>
+  <div class="app-shell">
+    <nav aria-label="Main navigation">
+      <h2>Explore Programs</h2>
+      <ul>
+        <li><a href="teachers.html">Teachers</a></li>
+        <li><a href="metals.html">Metals</a></li>
+        <li><a class="active" href="woods.html">Woods</a></li>
+        <li><a href="engineering.html">Engineering</a></li>
+        <li><a href="computer-science.html">Computer Science</a></li>
+        <li><a href="construction.html">Construction</a></li>
+        <li><a href="other-classes.html">Other Classes</a></li>
+      </ul>
+    </nav>
+    <main>
+      <a class="back-link" href="woods.html">Back to Woods</a>
+      <article class="content-card course-detail">
+        <h2>Woods III</h2>
+        <section class="course-meta">
+          <dl>
+            <dt>Name</dt>
+            <dd>Woods III</dd>
+            <dt>Teachers</dt>
+            <dd>Technology &amp; Engineering Education Staff</dd>
+            <dt>Grades</dt>
+            <dd>Recommended for grades 11-12</dd>
+          </dl>
+          <dl>
+            <dt>Prerequisites</dt>
+            <dd>Successful completion of two Woods II courses or instructor approval.</dd>
+            <dt>Number of Trimesters</dt>
+            <dd>1 trimester</dd>
+          </dl>
+        </section>
+        <section class="course-description">
+          <h3>Course Description</h3>
+          <p>Woods III is a capstone experience where students operate as independent designers and fabricators. Each learner develops a proposal, budget, and timeline for a signature project that demonstrates mastery of advanced woodworking skills.</p>
+          <p>Students integrate CNC machining, specialty joinery, and mixed materials such as glass or metal accents. Regular design reviews focus on problem-solving, risk management, and client communication.</p>
+          <p>The course culminates with a public presentation where students showcase their final work, document lessons learned, and outline next steps in their design journey.</p>
+        </section>
+        <section>
+          <h3>Photos</h3>
+          <div class="photo-gallery">
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Capstone projects progressing through assembly stages.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Students collaborating with mentors during design critiques.</figcaption>
+            </figure>
+            <figure>
+              <div class="photo-placeholder">Photo coming soon</div>
+              <figcaption>Completed Woods III projects featured at the showcase.</figcaption>
+            </figure>
+          </div>
+        </section>
+        <section class="faq">
+          <h3>Frequently Asked Questions</h3>
+          <details>
+            <summary>Can projects integrate other materials?</summary>
+            <p>Yes. Students are encouraged to incorporate metal, textiles, or electronics when it enhances their design intent.</p>
+          </details>
+          <details>
+            <summary>How much independent work is expected?</summary>
+            <p>Woods III emphasizes self-directed learning. Students manage their own schedules, check in with instructors, and document progress weekly.</p>
+          </details>
+          <details>
+            <summary>What support is available for complex builds?</summary>
+            <p>Instructors provide mentorship, connect students with industry partners, and approve specialized tooling requests to ensure safe execution.</p>
+          </details>
+        </section>
+      </article>
+    </main>
+  </div>
+</body>
+</html>

--- a/woods.html
+++ b/woods.html
@@ -38,6 +38,40 @@
           <h3>Showcase &amp; Community Impact</h3>
           <p>Learners present final pieces at the annual design showcase and partner with local organizations to build custom installations. Many graduates pursue careers in architecture, industrial design, or carpentry apprenticeships.</p>
         </div>
+        <section class="course-grid" aria-label="Woods courses">
+          <article class="course-card">
+            <h3><a href="woods-woods-i.html">Woods I</a></h3>
+            <p>Gain foundational woodworking skills with an emphasis on accurate measurement, safe tool operation, and finishing basics.</p>
+            <ul>
+              <li>Grades: 9-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="woods-woods-ii-cabinetmaking.html">Woods II: Cabinetmaking</a></h3>
+            <p>Design and build custom cabinetry while mastering case construction, hardware installation, and advanced joinery.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="woods-woods-ii-furniture-making.html">Woods II: Furniture Making</a></h3>
+            <p>Explore furniture design principles and produce heirloom-quality pieces using complex joinery and finishing techniques.</p>
+            <ul>
+              <li>Grades: 10-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+          <article class="course-card">
+            <h3><a href="woods-woods-iii.html">Woods III</a></h3>
+            <p>Lead independent projects that integrate CNC production, specialty tooling, and client collaboration experiences.</p>
+            <ul>
+              <li>Grades: 11-12</li>
+              <li>Length: 1 trimester</li>
+            </ul>
+          </article>
+        </section>
       </article>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- extend shared styling to support course cards, metadata panels, photo galleries, and FAQ accordions
- update each cluster overview page with course grids linking to the new detail pages
- add dedicated pages for every technology and engineering course with consistent metadata, descriptions, photos, and FAQ sections

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e052b3b888327af690ab9e43a982e)