### PR TITLE
Condense course metadata layout and drop redundant name row

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -547,37 +547,37 @@ main::after {
 
 .course-meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.5rem;
-  margin-top: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding: 1.1rem 1.4rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 20, 137, 0.1);
+  border-radius: 0.9rem;
+  box-shadow: 0 8px 18px rgba(6, 16, 64, 0.08);
 }
 
 .course-meta dl {
   margin: 0;
-  background: linear-gradient(135deg, rgba(0, 20, 137, 0.06), rgba(0, 48, 160, 0.08));
-  border: 1px solid rgba(0, 20, 137, 0.12);
-  border-radius: 0.95rem;
-  padding: 1.35rem 1.6rem;
-  box-shadow: 0 12px 24px rgba(6, 16, 64, 0.12);
+  display: grid;
+  gap: 0.35rem;
+  padding: 0;
 }
 
 .course-meta dt {
-  font-weight: 700;
-  margin-top: 0.75rem;
-  font-size: 0.9rem;
+  font-weight: 600;
+  font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--brand-primary);
-}
-
-.course-meta dt:first-of-type {
-  margin-top: 0;
+  color: var(--text-muted);
+  margin: 0;
 }
 
 .course-meta dd {
-  margin: 0.45rem 0 0;
-  font-size: 1rem;
-  color: var(--text-muted);
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--text-color);
+  font-weight: 600;
 }
 
 .back-link {

--- a/computer-science-ap-computer-science-a.html
+++ b/computer-science-ap-computer-science-a.html
@@ -30,8 +30,6 @@
         <h2>AP Computer Science A</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>AP Computer Science A</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/computer-science-ap-computer-science-principles.html
+++ b/computer-science-ap-computer-science-principles.html
@@ -30,8 +30,6 @@
         <h2>AP Computer Science Principles</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>AP Computer Science Principles</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/computer-science-networking-and-cybersecurity.html
+++ b/computer-science-networking-and-cybersecurity.html
@@ -30,8 +30,6 @@
         <h2>Networking &amp; Cybersecurity</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Networking &amp; Cybersecurity</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/computer-science-video-game-design-i.html
+++ b/computer-science-video-game-design-i.html
@@ -30,8 +30,6 @@
         <h2>Video Game Design I</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Video Game Design I</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/computer-science-video-game-design-ii.html
+++ b/computer-science-video-game-design-ii.html
@@ -30,8 +30,6 @@
         <h2>Video Game Design II</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Video Game Design II</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/computer-science-web-page-design.html
+++ b/computer-science-web-page-design.html
@@ -30,8 +30,6 @@
         <h2>Web Page Design</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Web Page Design</dd>
             <dt>Teachers</dt>
             <dd>Computer Science &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/construction-basic-home-repair.html
+++ b/construction-basic-home-repair.html
@@ -30,8 +30,6 @@
         <h2>Basic Home Repair</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Basic Home Repair</dd>
             <dt>Teachers</dt>
             <dd>Construction &amp; Trades Staff</dd>
             <dt>Grades</dt>

--- a/construction-small-structures.html
+++ b/construction-small-structures.html
@@ -30,8 +30,6 @@
         <h2>Small Structures</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Small Structures</dd>
             <dt>Teachers</dt>
             <dd>Construction &amp; Trades Staff</dd>
             <dt>Grades</dt>

--- a/engineering-engineering-i.html
+++ b/engineering-engineering-i.html
@@ -30,8 +30,6 @@
         <h2>Engineering I</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Engineering I</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/engineering-engineering-ii-applied-engineering.html
+++ b/engineering-engineering-ii-applied-engineering.html
@@ -30,8 +30,6 @@
         <h2>Engineering II: Applied Engineering</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Engineering II: Applied Engineering</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/engineering-engineering-ii-manufacturing.html
+++ b/engineering-engineering-ii-manufacturing.html
@@ -30,8 +30,6 @@
         <h2>Engineering II: Manufacturing</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Engineering II: Manufacturing</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/engineering-robotics.html
+++ b/engineering-robotics.html
@@ -30,8 +30,6 @@
         <h2>Robotics</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Robotics</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/engineering-solidworks-certified.html
+++ b/engineering-solidworks-certified.html
@@ -30,8 +30,6 @@
         <h2>SOLIDWORKS Certified</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>SOLIDWORKS Certified</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/metals-foundations-of-metals.html
+++ b/metals-foundations-of-metals.html
@@ -30,8 +30,6 @@
         <h2>Foundations of Metals</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Foundations of Metals</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/metals-general-metals.html
+++ b/metals-general-metals.html
@@ -30,8 +30,6 @@
         <h2>General Metals</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>General Metals</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/metals-mass-production.html
+++ b/metals-mass-production.html
@@ -30,8 +30,6 @@
         <h2>Mass Production</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Mass Production</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/metals-sheet-metal.html
+++ b/metals-sheet-metal.html
@@ -30,8 +30,6 @@
         <h2>Sheet Metal</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Sheet Metal</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/metals-welding.html
+++ b/metals-welding.html
@@ -30,8 +30,6 @@
         <h2>Welding</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Welding</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/other-architecture.html
+++ b/other-architecture.html
@@ -30,8 +30,6 @@
         <h2>Architecture</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Architecture</dd>
             <dt>Teachers</dt>
             <dd>Architecture &amp; Design Staff</dd>
             <dt>Grades</dt>

--- a/other-aviation-i.html
+++ b/other-aviation-i.html
@@ -30,8 +30,6 @@
         <h2>Aviation I</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Aviation I</dd>
             <dt>Teachers</dt>
             <dd>Aviation &amp; STEM Staff</dd>
             <dt>Grades</dt>

--- a/other-aviation-ii.html
+++ b/other-aviation-ii.html
@@ -30,8 +30,6 @@
         <h2>Aviation II</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Aviation II</dd>
             <dt>Teachers</dt>
             <dd>Aviation &amp; STEM Staff</dd>
             <dt>Grades</dt>

--- a/other-electronics.html
+++ b/other-electronics.html
@@ -30,8 +30,6 @@
         <h2>Electronics</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Electronics</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/other-fishing.html
+++ b/other-fishing.html
@@ -30,8 +30,6 @@
         <h2>Fishing</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Fishing</dd>
             <dt>Teachers</dt>
             <dd>Outdoor Education Staff</dd>
             <dt>Grades</dt>

--- a/other-robotics-open-shop.html
+++ b/other-robotics-open-shop.html
@@ -30,8 +30,6 @@
         <h2>Robotics Open Shop</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Robotics Open Shop</dd>
             <dt>Teachers</dt>
             <dd>Robotics &amp; Engineering Staff</dd>
             <dt>Grades</dt>

--- a/other-small-engines.html
+++ b/other-small-engines.html
@@ -30,8 +30,6 @@
         <h2>Small Engines</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Small Engines</dd>
             <dt>Teachers</dt>
             <dd>Automotive &amp; Power Equipment Staff</dd>
             <dt>Grades</dt>

--- a/woods-woods-i.html
+++ b/woods-woods-i.html
@@ -30,8 +30,6 @@
         <h2>Woods I</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Woods I</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/woods-woods-ii-cabinetmaking.html
+++ b/woods-woods-ii-cabinetmaking.html
@@ -30,8 +30,6 @@
         <h2>Woods II: Cabinetmaking</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Woods II: Cabinetmaking</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/woods-woods-ii-furniture-making.html
+++ b/woods-woods-ii-furniture-making.html
@@ -30,8 +30,6 @@
         <h2>Woods II: Furniture Making</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Woods II: Furniture Making</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>

--- a/woods-woods-iii.html
+++ b/woods-woods-iii.html
@@ -30,8 +30,6 @@
         <h2>Woods III</h2>
         <section class="course-meta">
           <dl>
-            <dt>Name</dt>
-            <dd>Woods III</dd>
             <dt>Teachers</dt>
             <dd>Technology &amp; Engineering Education Staff</dd>
             <dt>Grades</dt>


### PR DESCRIPTION
## Summary
- remove redundant Name entries from every course detail page so metadata focuses on actionable information
- refresh course metadata styling to use a lighter, more compact grid treatment with reduced padding and softer background

## Testing
- No automated tests were run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e1118944883279d332ba480bb764a)