### PR TITLE
Remove grades and length prefixes from course cards

### DIFF
--- a/computer-science.html
+++ b/computer-science.html
@@ -43,48 +43,48 @@
             <h3><a href="computer-science-video-game-design-i.html">Video Game Design I</a></h3>
             <p>Learn game design principles, storytelling, and introductory programming to build playable 2D experiences.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="computer-science-video-game-design-ii.html">Video Game Design II</a></h3>
             <p>Expand game projects with advanced mechanics, collaborative sprints, and user experience playtesting.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="computer-science-ap-computer-science-principles.html">AP Computer Science Principles</a></h3>
             <p>Investigate computing innovations, data, and creative coding while preparing for the AP Performance Tasks and exam.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 3 trimesters</li>
+              <li>10-12</li>
+              <li>3 trimesters</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="computer-science-ap-computer-science-a.html">AP Computer Science A</a></h3>
             <p>Master Java programming, object-oriented design, and algorithm analysis in alignment with AP CSA exam topics.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 3 trimesters</li>
+              <li>10-12</li>
+              <li>3 trimesters</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="computer-science-web-page-design.html">Web Page Design</a></h3>
             <p>Build responsive websites using HTML, CSS, and JavaScript with a focus on accessibility and user-centered design.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="computer-science-networking-and-cybersecurity.html">Networking &amp; Cybersecurity</a></h3>
             <p>Configure small networks, troubleshoot connectivity, and practice defensive strategies against digital threats.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>

--- a/construction.html
+++ b/construction.html
@@ -43,16 +43,16 @@
             <h3><a href="construction-basic-home-repair.html">Basic Home Repair</a></h3>
             <p>Practice essential maintenance tasks including drywall patching, fixture replacement, and preventative home care.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="construction-small-structures.html">Small Structures</a></h3>
             <p>Design and build sheds, playhouses, and other small-scale structures using framing, roofing, and finishing skills.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>

--- a/engineering.html
+++ b/engineering.html
@@ -43,40 +43,40 @@
             <h3><a href="engineering-engineering-i.html">Engineering I</a></h3>
             <p>Explore the engineering design process through rapid prototyping, CAD modeling, and collaborative design challenges.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="engineering-engineering-ii-manufacturing.html">Engineering II: Manufacturing</a></h3>
             <p>Combine automation concepts with machining and fabrication workflows to produce reliable, repeatable parts.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="engineering-engineering-ii-applied-engineering.html">Engineering II: Applied Engineering</a></h3>
             <p>Apply mechanical, electrical, and software concepts to solve open-ended problems in multidisciplinary project teams.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="engineering-solidworks-certified.html">SOLIDWORKS Certified</a></h3>
             <p>Prepare for the CSWA exam with advanced parametric modeling, assemblies, and drawing standards using SOLIDWORKS.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="engineering-robotics.html">Robotics</a></h3>
             <p>Design, build, and program competition-ready robots while practicing systems integration and iterative testing.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>

--- a/metals.html
+++ b/metals.html
@@ -41,40 +41,40 @@
             <h3><a href="metals-foundations-of-metals.html">Foundations of Metals</a></h3>
             <p>Build confidence with hand tools, measurement, and introductory fabrication projects while developing strong safety habits.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="metals-general-metals.html">General Metals</a></h3>
             <p>Advance layout, cutting, and assembly skills through multi-step projects that emphasize precision and craftsmanship.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="metals-welding.html">Welding</a></h3>
             <p>Focus on MIG, TIG, and stick welding techniques while preparing for entry-level certifications and industry expectations.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="metals-sheet-metal.html">Sheet Metal</a></h3>
             <p>Create custom enclosures and ducting components using shearing, forming, and fastening processes used in industry.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="metals-mass-production.html">Mass Production</a></h3>
             <p>Collaborate on small-batch product runs to learn workflow planning, quality control, and efficient fabrication methods.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>

--- a/other-classes.html
+++ b/other-classes.html
@@ -43,56 +43,56 @@
             <h3><a href="other-electronics.html">Electronics</a></h3>
             <p>Investigate circuits, components, and testing equipment while building functional prototypes and troubleshooting systems.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-fishing.html">Fishing</a></h3>
             <p>Study aquatic ecosystems, tackle selection, and conservation practices alongside hands-on angling experiences.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-small-engines.html">Small Engines</a></h3>
             <p>Disassemble and rebuild engines to understand combustion principles, diagnostics, and preventative maintenance.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-aviation-i.html">Aviation I</a></h3>
             <p>Discover aviation history, flight theory, and simulator practice while exploring careers in aerospace.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-aviation-ii.html">Aviation II</a></h3>
             <p>Dive deeper into navigation, weather analysis, and flight planning while advancing simulator proficiency.</p>
             <ul>
-              <li>Grades: 11-12</li>
-              <li>Length: 1 trimester</li>
+              <li>11-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-architecture.html">Architecture</a></h3>
             <p>Blend artistic vision with technical drawing as you design structures using both hand sketching and CAD tools.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="other-robotics-open-shop.html">Robotics Open Shop</a></h3>
             <p>Collaborate with peers to iterate on competition robots, practice advanced fabrication, and mentor younger teams.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>

--- a/woods.html
+++ b/woods.html
@@ -43,32 +43,32 @@
             <h3><a href="woods-woods-i.html">Woods I</a></h3>
             <p>Gain foundational woodworking skills with an emphasis on accurate measurement, safe tool operation, and finishing basics.</p>
             <ul>
-              <li>Grades: 9-12</li>
-              <li>Length: 1 trimester</li>
+              <li>9-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="woods-woods-ii-cabinetmaking.html">Woods II: Cabinetmaking</a></h3>
             <p>Design and build custom cabinetry while mastering case construction, hardware installation, and advanced joinery.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="woods-woods-ii-furniture-making.html">Woods II: Furniture Making</a></h3>
             <p>Explore furniture design principles and produce heirloom-quality pieces using complex joinery and finishing techniques.</p>
             <ul>
-              <li>Grades: 10-12</li>
-              <li>Length: 1 trimester</li>
+              <li>10-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
           <article class="course-card">
             <h3><a href="woods-woods-iii.html">Woods III</a></h3>
             <p>Lead independent projects that integrate CNC production, specialty tooling, and client collaboration experiences.</p>
             <ul>
-              <li>Grades: 11-12</li>
-              <li>Length: 1 trimester</li>
+              <li>11-12</li>
+              <li>1 trimester</li>
             </ul>
           </article>
         </section>


### PR DESCRIPTION
## Summary
- remove the "Grades:" label from each course card list item so only the grade range remains
- strip the "Length:" prefix from the course duration rows to match the updated style

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e14cc3a5c83278faa7a935c57b41f)